### PR TITLE
Bugfix to allow longs to be passed into braintree param dictionaries

### DIFF
--- a/braintree/util/generator.py
+++ b/braintree/util/generator.py
@@ -50,7 +50,7 @@ class Generator(object):
             return open_tag + self.__generate_boolean(value) + close_tag
         elif isinstance(value, (int, long)) and not isinstance(value, bool):
             open_tag = "<" + key + " type=\"integer\">"
-            return open_tag + ("%d" % value) + close_tag
+            return open_tag + str(value) + close_tag
         elif isinstance(value, types.NoneType):
             return open_tag + close_tag
         elif isinstance(value, datetime.datetime) or isinstance(value, datetime.date):


### PR DESCRIPTION
Hi guys - really small fix for an issue encountered whilst implementing braintree for my Django-based app.  Since the type of some of the Django ORM primary keys is 'long' rather than 'int', you need explicit support for this otherwise the XML generator bails out for unknown type.

Thanks,
Glen
