### PR TITLE
Relax requirements for Requests.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,6 @@ setup(
     url="https://www.braintreepayments.com/docs/python",
     packages=["braintree", "braintree.exceptions", "braintree.util", "braintree.test", "braintree.util.http_strategy"],
     package_data={"braintree": ["ssl/*"]},
-    install_requires=["requests>=0.11.1,<1.0"],
+    install_requires=["requests>=0.11.1,<1.2"],
     zip_safe=False
 )


### PR DESCRIPTION
Running tests seem to indicate that Requests up to and including version 1.1 does not break the client library. Because of breaking differences between the 0.x and 1.x series, allowing use of the library alongside libraries using the Requests 1.x series would be a big help.
