### PR TITLE
Fixed httplib import error on python 3

### DIFF
--- a/braintree/util/http_strategy/httplib_strategy.py
+++ b/braintree/util/http_strategy/httplib_strategy.py
@@ -1,4 +1,8 @@
-import httplib
+# Fixes python 3 incompatibility
+try:
+    import httplib
+except ImportError:
+    import http.client as httplib
 
 class HttplibStrategy(object):
     def __init__(self, config, environment):

--- a/braintree/util/http_strategy/pycurl_strategy.py
+++ b/braintree/util/http_strategy/pycurl_strategy.py
@@ -1,6 +1,11 @@
-import httplib
 import StringIO
 
+# Fixes python 3 incompatibility
+try:
+    import httplib
+except ImportError:
+    import http.client as httplib
+    
 try:
     import pycurl
 except ImportError:


### PR DESCRIPTION
Please look at https://github.com/braintree/braintree_python/issues/32 for more information about this pull request.
