### PR TITLE
Fix AttributeError for use_unsafe_ssl option when instantiating config

### DIFF
--- a/braintree/configuration.py
+++ b/braintree/configuration.py
@@ -39,13 +39,15 @@ class Configuration(object):
 
 .. [1] `URL Fetch Python API Overview <https://developers.google.com/appengine/docs/python/urlfetch/overview>`_
     """
+
+    use_unsafe_ssl = False
+
     @staticmethod
     def configure(environment, merchant_id, public_key, private_key, http_strategy=None):
         Configuration.environment = environment
         Configuration.merchant_id = merchant_id
         Configuration.public_key = public_key
         Configuration.private_key = private_key
-        Configuration.use_unsafe_ssl = False
         Configuration.default_http_strategy = http_strategy
 
     @staticmethod
@@ -81,7 +83,6 @@ class Configuration(object):
         self.merchant_id = merchant_id
         self.public_key = public_key
         self.private_key = private_key
-        self.use_unsafe_ssl = getattr(Configuration, 'use_unsafe_ssl', False)
 
         if http_strategy:
             self._http_strategy = http_strategy(self, self.environment)
@@ -98,7 +99,7 @@ class Configuration(object):
         return braintree.util.http.Http(self)
 
     def http_strategy(self):
-        if self.use_unsafe_ssl:
+        if Configuration.use_unsafe_ssl:
             return braintree.util.http_strategy.httplib_strategy.HttplibStrategy(self, self.environment)
         else:
             return self._http_strategy


### PR DESCRIPTION
Consider the following code (lifted from this stackoverflow post [1]):

```
import braintree

config = braintree.Configuration(
    environment=braintree.Environment.Sandbox,
    merchant_id='merchant_id',
    public_key='public_key',
    private_key='private_key'
)
gateway = braintree.BraintreeGateway(config)
result = gateway.transaction.create({
    'amount': '10.00',
})
```

This results in the following exception:

```
jay@coltrane:~/github/braintree_python$ python test_braintree.py
Traceback (most recent call last):
  File "test_braintree.py", line 14, in <module>
    'amount': '10.00',
  File "/home/jay/github/braintree_python/braintree/transaction_gateway.py", line 33, in create
    return self._post("/transactions", {"transaction": params})
  File "/home/jay/github/braintree_python/braintree/transaction_gateway.py", line 137, in _post
    response = self.config.http().post(url, params)
  File "/home/jay/github/braintree_python/braintree/util/http.py", line 40, in post
    return self.__http_do("POST", path, params)
  File "/home/jay/github/braintree_python/braintree/util/http.py", line 52, in __http_do
    http_strategy = self.config.http_strategy()
  File "/home/jay/github/braintree_python/braintree/configuration.py", line 103, in http_strategy
    if Configuration.use_unsafe_ssl:
AttributeError: type object 'Configuration' has no attribute 'use_unsafe_ssl'
```

This pull request fixes that. Some notes:
1. I tried to keep the same interface for specifying the `use_unsafe_url` option (as a class variable) rather than adding it as an optional parameter in the constructor. I assume you do this because you don't really want people using this feature.
2. But I also realize there are other ways to have implemented this. So I'm open to using a different technique.
3. I tested this using a test script, because the current tests depend on a local dev server running. If you want, I can update `test_helper.py` with my sandbox credentials and try running tests.
4. Similarly, it looks like there are very few tests pertaining to this code path (of the `use_unsafe_ssl` option.) I'm happy to write some if I could have some guidance on the best way to do so.

Thank you!

Jay

[1] http://stackoverflow.com/a/21263451/3788
