### PR TITLE
Declare package version in 'setup.py' to enable installing 'requests' as a dependency

### DIFF
--- a/braintree/version.py
+++ b/braintree/version.py
@@ -1,1 +1,3 @@
-Version = "3.0.0-beta"
+import pkg_resources
+
+Version = pkg_resources.get_distribution("braintree").version

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
-import braintree
 from distutils.core import setup
 setup(
     name="braintree",
-    version=braintree.version.Version,
+    version="3.0.0-beta",
     description="Braintree Python Library",
     author="Braintree",
     author_email="support@braintreepayments.com",


### PR DESCRIPTION
Importing the `braintree.version` module in `setup.py` will import the `braintree` package which in turn, by importing all its modules into its namespace will end in the chain of imports attempt to import `requests`. This prevents `setup.py` from working correctly if `requests` hasn't been previously installed manually.

The proposed change, by moving the package version declaration to `setup.py` and then reading that in `braintree.version` avoids this problem and enables the automatic install of `requests` as a dependency.
