### PR TITLE
fix python 3 compatibility for oauth_gateway.py

### DIFF
--- a/braintree/oauth_gateway.py
+++ b/braintree/oauth_gateway.py
@@ -49,7 +49,7 @@ class OAuthGateway(object):
 
         params = reduce(clean_values, params.items(), [])
         query = params + user_params + business_params
-        query_string = "&".join(map(lambda k, v: quote_plus(k) + "=" + quote_plus(v), query))
+        query_string = "&".join(map(lambda kv_pair: quote_plus(kv_pair[0]) + "=" + quote_plus(kv_pair[1]), query))
         return self._sign_url(self.config.environment.base_url + "/oauth/connect?" + query_string)
 
     def _sub_query(self, params, root):
@@ -57,7 +57,7 @@ class OAuthGateway(object):
             sub_query = params.pop(root)
         else:
             sub_query = {}
-        query = map(lambda k, v: (root + "[" + k + "]",str(v)), sub_query.items())
+        query = map(lambda kv_pair: (root + "[" + kv_pair[0] + "]", str(kv_pair[1])), sub_query.items())
         return query
 
     def _sign_url(self, url):

--- a/braintree/oauth_gateway.py
+++ b/braintree/oauth_gateway.py
@@ -3,7 +3,12 @@ from braintree.error_result import ErrorResult
 from braintree.successful_result import SuccessfulResult
 from braintree.exceptions.not_found_error import NotFoundError
 from braintree.oauth_credentials import OAuthCredentials
-from urllib import quote_plus
+import sys
+if sys.version_info[0] == 2:
+    from urllib import quote_plus
+else:
+    from urllib.parse import quote_plus
+    from functools import reduce
 
 class OAuthGateway(object):
     def __init__(self, gateway):
@@ -34,7 +39,8 @@ class OAuthGateway(object):
         user_params = self._sub_query(params, "user")
         business_params = self._sub_query(params, "business")
 
-        def clean_values(accumulator, (key, value)):
+        def clean_values(accumulator, kv_pair):
+            key, value = kv_pair
             if isinstance(value, list):
                 accumulator += map(lambda v: (key + "[]", v), value)
             else:
@@ -43,7 +49,7 @@ class OAuthGateway(object):
 
         params = reduce(clean_values, params.items(), [])
         query = params + user_params + business_params
-        query_string = "&".join(map(lambda (k, v): quote_plus(k) + "=" + quote_plus(v), query))
+        query_string = "&".join(map(lambda k, v: quote_plus(k) + "=" + quote_plus(v), query))
         return self._sign_url(self.config.environment.base_url + "/oauth/connect?" + query_string)
 
     def _sub_query(self, params, root):
@@ -51,7 +57,7 @@ class OAuthGateway(object):
             sub_query = params.pop(root)
         else:
             sub_query = {}
-        query = map(lambda (k,v): (root + "[" + k + "]",str(v)), sub_query.items())
+        query = map(lambda k, v: (root + "[" + k + "]",str(v)), sub_query.items())
         return query
 
     def _sign_url(self, url):


### PR DESCRIPTION
All unit tests failed with Python 3 with release 3.17.0:

```
======================================================================
ERROR: Failure: SyntaxError (invalid syntax (oauth_gateway.py, line 37))
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.4/site-packages/nose/failure.py", line 39, in runTest
    raise self.exc_val.with_traceback(self.tb)
  File "/usr/lib/python3.4/site-packages/nose/loader.py", line 418, in loadTestsFromName
    addr.filename, addr.module)
  File "/usr/lib/python3.4/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/usr/lib/python3.4/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/usr/lib/python3.4/imp.py", line 235, in load_module
    return load_source(name, filename, file)
  File "/usr/lib/python3.4/imp.py", line 171, in load_source
    module = methods.load()
  File "<frozen importlib._bootstrap>", line 1220, in load
  File "<frozen importlib._bootstrap>", line 1200, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1129, in _exec
  File "<frozen importlib._bootstrap>", line 1471, in exec_module
  File "<frozen importlib._bootstrap>", line 321, in _call_with_frames_removed
  File "/build/python-braintree/src/braintree_python-3.17.0/tests/unit/test_xml_util.py", line 1, in <module>
    from tests.test_helper import *
  File "/build/python-braintree/src/braintree_python-3.17.0/tests/test_helper.py", line 14, in <module>
    from braintree import *
  File "/build/python-braintree/src/braintree_python-3.17.0/braintree/__init__.py", line 7, in <module>
    from braintree.braintree_gateway import BraintreeGateway
  File "/build/python-braintree/src/braintree_python-3.17.0/braintree/braintree_gateway.py", line 10, in <module>
    from braintree.oauth_gateway import OAuthGateway
  File "/build/python-braintree/src/braintree_python-3.17.0/braintree/oauth_gateway.py", line 37
    def clean_values(accumulator, (key, value)):
                                  ^
SyntaxError: invalid syntax
```

Tuple parameter unpacking was removed since Python 3.0 (PEP 3113), and there is also reference to `urllib.quote_plus` and `reduce()` which are not directly usable in Python 3. This PR addresses all what I have found so far and make the tests passing again.