### PR TITLE
Support iterator protocol in ResourceCollections

### DIFF
--- a/braintree/resource_collection.py
+++ b/braintree/resource_collection.py
@@ -1,9 +1,9 @@
 class ResourceCollection(object):
     """
-    A class representing results from a search.  Iterate over the results by calling items::
+    A class representing results from a search. Supports the iterator protocol::
 
         results = braintree.Transaction.search("411111")
-        for transaction in results.items:
+        for transaction in results:
             print transaction.id
     """
 
@@ -32,6 +32,9 @@ class ResourceCollection(object):
         for batch in self.__batch_ids():
             for item in self.__method(self.__query, batch):
                 yield item
+
+    def __iter__(self):
+        return self.items
 
     def __batch_ids(self):
         for i in range(0, len(self.__ids), self.__page_size):

--- a/tests/unit/test_resource_collection.py
+++ b/tests/unit/test_resource_collection.py
@@ -1,6 +1,13 @@
 from tests.test_helper import *
 
 class TestResourceCollection(unittest.TestCase):
+    collection_data = {
+        "search_results": {
+            "page_size": 2,
+            "ids": ["0", "1", "2", "3", "4"]
+        }
+    }
+
     class TestResource:
         items = ["a", "b", "c", "d", "e"]
 
@@ -9,13 +16,7 @@ class TestResourceCollection(unittest.TestCase):
             return [TestResourceCollection.TestResource.items[int(id)] for id in ids]
 
     def test_iterating_over_contents(self):
-        collection_data = {
-            "search_results": {
-                "page_size": 2,
-                "ids": ["0", "1", "2", "3", "4"]
-            }
-        }
-        collection = ResourceCollection("some_query", collection_data, TestResourceCollection.TestResource.fetch)
+        collection = ResourceCollection("some_query", self.collection_data, TestResourceCollection.TestResource.fetch)
         new_items = []
         index = 0
         for item in collection.items:

--- a/tests/unit/test_resource_collection.py
+++ b/tests/unit/test_resource_collection.py
@@ -26,3 +26,7 @@ class TestResourceCollection(unittest.TestCase):
 
         self.assertEquals(5, len(new_items))
 
+    def test_iterate_using_iterator_protocol(self):
+        collection = ResourceCollection("some_query", self.collection_data, TestResourceCollection.TestResource.fetch)
+        for test_elem, coll_elem in zip(self.TestResource.items, collection):
+            self.assertEqual(test_elem, coll_elem)


### PR DESCRIPTION
Make the `ResourceCollection` class implement the iterator
protocol. This is the idiomatic way to iterate in python and doesn't
create any suprises.
    
The `ResourceCollection.items()` method is unchanged (for backwards
compatibility). So `__iter__` simply calls that for now.
