### PR TITLE
persist original traceback...

### DIFF
--- a/braintree/configuration.py
+++ b/braintree/configuration.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import braintree
 from braintree.exceptions.configuration_error import ConfigurationError
 from braintree.credentials_parser import CredentialsParser

--- a/braintree/util/http.py
+++ b/braintree/util/http.py
@@ -69,7 +69,7 @@ class Http(object):
             if self.config.wrap_http_exceptions:
                 http_strategy.handle_exception(e)
             else:
-                raise e
+                raise sys.exc_info()[0], sys.exc_info()[1], sys.exc_info()[2]
 
         if Http.is_error_status(status):
             Http.raise_exception_from_status(status)


### PR DESCRIPTION
... to help with debugging. `raise e` trashes the original traceback and line numbers.