### PR TITLE
Fix tests in Python 3.x

### DIFF
--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -64,7 +64,7 @@ warnings.showwarning = showwarning
 
 def skip_sub_merchant_account_tests():
     output, _ = Popen(["git", "rev-parse", "--abbrev-ref", "HEAD"], stdout=PIPE).communicate()
-    branch_supports_sub_merchant_accounts = bool(re.match(r"^marketplace_v2$|^btmkpl", output.strip(), re.IGNORECASE))
+    branch_supports_sub_merchant_accounts = bool(re.match(br"^marketplace_v2$|^btmkpl", output.strip(), re.IGNORECASE))
     return not branch_supports_sub_merchant_accounts
 
 class TestHelper(object):


### PR DESCRIPTION
Without the patch, there are 44 errors when running the tests with Python 3.x. For example:

```
======================================================================
ERROR: tests.unit.merchant_account.test_address_details.skip_sub_merchant_account_tests
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.5/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/usr/lib/python3.5/site-packages/nose/util.py", line 620, in newfunc
    return func(*arg, **kw)
  File "/home/felix/projects/braintree_python/tests/test_helper.py", line 67, in skip_sub_merchant_account_tests
    branch_supports_sub_merchant_accounts = bool(re.match(r"^marketplace_v2$|^btmkpl", output.strip(), re.IGNORECASE))
  File "/usr/lib/python3.5/re.py", line 163, in match
    return _compile(pattern, flags).match(string)
TypeError: cannot use a string pattern on a bytes-like object
```