### PR TITLE
Accept unicode during param key building

### DIFF
--- a/braintree/resource.py
+++ b/braintree/resource.py
@@ -17,7 +17,7 @@ class Resource(AttributeGetter):
 
     @staticmethod
     def __flattened_params_keys(params, parent=None):
-        if isinstance(params, str):
+        if isinstance(params, str) or isinstance(params, unicode):
             return [ "%s[%s]" % (parent, params) ]
         else:
             keys = []


### PR DESCRIPTION
Many Python applications and frameworks use unicode strings wherever
possible.  This makes it a bit awkward to do things like update a
subscription, since the following code raises an error:

    braintree.Subscription.update('subscription_id', {
            "add_ons": {
                "add": [
                    {
                        "inherited_from_id": "addon1",
                    }
                ],
                "remove": [u"addon2"]
            },
        })

(Note the unicode add-on name in the "remove" list).

Specifically, it raises:

    AttributeError: 'unicode' object has no attribute 'items'

from resource.py:24.

Be a bit more permissive by allowing instances of str *or* unicode to be
used as a key, allowing the above code to succeed.