### PR TITLE
setup.py improvements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,13 @@
-from distutils.core import setup
+from setuptools import setup
+
 setup(
     name="braintree",
     version="3.29.2",
     description="Braintree Python Library",
+    long_description="""
+    For more information see our `documentation <https://developers.braintreepayments.com/python/sdk/server/overview>`_
+    or the `Github repo <https://github.com/braintree/braintree_python>`_.
+    """,
     author="Braintree",
     author_email="support@braintreepayments.com",
     url="https://developers.braintreepayments.com/python/sdk/server/overview",
@@ -10,7 +15,7 @@ setup(
     package_data={"braintree": ["ssl/*"]},
     install_requires=["requests>=0.11.1,<3.0"],
     zip_safe=False,
-    classifiers = [
+    classifiers=[
         "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.3",


### PR DESCRIPTION
Rehash of the rejected #73.

I visited the PyPI page as I was looking at dependencies to upgrade and found it a little bare, so I've made these changes:

- Add a link from PyPI direct to the Github repository, so people can find the changelog.
- Use `setuptools` rather than `distutils`, because the future is now.