### PR TITLE
setup.py improvements and universal wheels

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,7 @@ namespace :pypi do
 
   desc "Upload a new version to PyPI"
   task :upload => :clean do
-    sh "python setup.py sdist upload"
+    sh "python setup.py sdist bdist_wheel upload"
   end
 end
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
-long_description="""
+long_description = """
         The Braintree Python SDK provides integration access to the Braintree Gateway.
 
         1. https://github.com/braintree/braintree_python - README and Samples
@@ -20,7 +23,7 @@ setup(
     install_requires=["requests>=0.11.1,<3.0"],
     zip_safe=False,
     license="MIT",
-    classifiers = [
+    classifiers=[
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",


### PR DESCRIPTION
Re-re-hash of the rejected #74 and #75.

Includes these changes:
- Add a link from PyPI direct to the Github repository, so people can find the changelog. It's really annoying when upgrading to have to resort to Google-sleuthing to find the changelog to see if there are any breaking changes.
- Prefer to use `setuptools` rather than `distutils`, because the future is now. `setuptools` is installed in nearly every Python environment these days because `pip` always includes it. It supports deployment of universal wheels. By falling back to `distutils` when it can't be imported, we still support source installations in legacy environments.
- Include releasing as a universal wheel to speed up users' installs. See #75 for instructions.
