### PR TITLE
Re-re-rehash of the rejected #74, #75 and #76 

### DIFF
--- a/dist.sh
+++ b/dist.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+python3 setup.py sdist
+pip wheel . -w dist
+twine upload dist/braintree-*

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,4 @@
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from distutils.core import setup
 
 setup(
     name="braintree",

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,16 @@
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
 setup(
     name="braintree",
     version="3.34.0",
     description="Braintree Python Library",
+    long_description="""
+    For more information see our `documentation <https://developers.braintreepayments.com/python/sdk/server/overview>`_
+    or the `Github repo <https://github.com/braintree/braintree_python>`_.
+    """,
     author="Braintree",
     author_email="support@braintreepayments.com",
     url="https://developers.braintreepayments.com/python/sdk/server/overview",


### PR DESCRIPTION
Re-re-rehash of the rejected #74, #75 and #76 

Includes these changes:

* Add a link from PyPI direct to the Github repository, so people can find the changelog. It's really annoying when upgrading to have to resort to Google-sleuthing to find the changelog to see if there are any breaking changes.
* Revert back to only using distutils (pip replaces this with setuptools transparently when building wheels)
* Include releasing as a universal wheel to speed up users' installs. Run ./dist.sh to distribute your legacy sdist and your wheels

