### PR TITLE
Increase granularity in TimeoutError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## unreleased
+* Add `braintree.exceptions.http.timeout_error.ConnectTimeoutError`
+* Add `braintree.exceptions.http.timeout_error.ReadTimeoutError`
+* Raise introduced exceptions while allowing for backwards compatibility through inheritance.
+
 ## 3.54.0
 * Add `payment_method_nonce` field to `LocalPaymentCompleted` webhook
 * Add `transaction` field to `LocalPaymentCompleted` webhook

--- a/braintree/exceptions/http/timeout_error.py
+++ b/braintree/exceptions/http/timeout_error.py
@@ -2,3 +2,11 @@ from braintree.exceptions.unexpected_error import UnexpectedError
 
 class TimeoutError(UnexpectedError):
     pass
+
+
+class ConnectTimeoutError(TimeoutError):
+    pass
+
+
+class ReadTimeoutError(TimeoutError):
+    pass

--- a/braintree/util/http.py
+++ b/braintree/util/http.py
@@ -20,6 +20,8 @@ from braintree.exceptions.unexpected_error import UnexpectedError
 from braintree.exceptions.http.connection_error import ConnectionError
 from braintree.exceptions.http.invalid_response_error import InvalidResponseError
 from braintree.exceptions.http.timeout_error import TimeoutError
+from braintree.exceptions.http.timeout_error import ConnectTimeoutError
+from braintree.exceptions.http.timeout_error import ReadTimeoutError
 
 class Http(object):
     class ContentType(object):
@@ -120,7 +122,11 @@ class Http(object):
         return [response.status_code, response.text]
 
     def handle_exception(self, exception):
-        if isinstance(exception, requests.exceptions.ConnectionError):
+        if isinstance(exception, requests.exceptions.ReadTimeout):
+            raise ReadTimeoutError(exception)
+        elif isinstance(exception, requests.exceptions.ConnectTimeout):
+            raise ConnectTimeoutError(exception)
+        elif isinstance(exception, requests.exceptions.ConnectionError):
             raise ConnectionError(exception)
         elif isinstance(exception, requests.exceptions.HTTPError):
             raise InvalidResponseError(exception)

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -1,6 +1,7 @@
 import traceback
 
 from tests.test_helper import *
+from braintree.exceptions.http.timeout_error import *
 from braintree.attribute_getter import AttributeGetter
 
 class TestHttp(unittest.TestCase):
@@ -108,3 +109,19 @@ class TestHttp(unittest.TestCase):
                 "wrap_http_exceptions": False})
 
         return Http(config, "fake_environment")
+
+    @raises(ReadTimeoutError)
+    def test_raise_read_timeout_error(self):
+        def test_http_do_strategy(http_verb, path, headers, request_body):
+            return (200, "")
+
+        http = self.setup_http_strategy(test_http_do_strategy)
+        http.handle_exception(requests.exceptions.ReadTimeout())
+
+    @raises(ConnectTimeoutError)
+    def test_raise_read_timeout_error(self):
+        def test_http_do_strategy(http_verb, path, headers, request_body):
+            return (200, "")
+
+        http = self.setup_http_strategy(test_http_do_strategy)
+        http.handle_exception(requests.exceptions.ConnectTimeout())


### PR DESCRIPTION
# Summary

Context
-------
Increase the granularity of TimeoutError by introducing child classes,
ConnectTimeoutError and ReadTimeoutError to parity the exceptions
raised from the requests library.

Changes
-------
* Introduce child classes in `braintree.exceptions.http.timeout_error`
* Handle ReadTimeouts in `braintree.util.handle_exception`
* Add integration tests

References
----------
https://github.com/braintree/braintree_python/issues/104


# Checklist

- [x] Added changelog entry
- [x] Ran unit tests (`nosetests tests/unit`)
