### PR TITLE
Add Apple Pay domain management support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.57.2
+## unreleased
 * Add support for managing Apple Pay domains
 
 ## 3.57.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
+## 3.57.2
+* Add support for managing Apple Pay domains
+
 ## 3.57.1
 * Set correct version for PyPi
 
-## 3.57.0 
+## 3.57.0
 * Forward `processor_comments` to `forwarded_comments`
 * Add Venmo 'TokenIssuance' gateway rejection reason
 * Add `AmountNotSupportedByProcessor` to validation error

--- a/braintree/__init__.py
+++ b/braintree/__init__.py
@@ -6,6 +6,7 @@ from braintree.address_gateway import AddressGateway
 from braintree.amex_express_checkout_card import AmexExpressCheckoutCard
 from braintree.android_pay_card import AndroidPayCard
 from braintree.apple_pay_card import ApplePayCard
+from braintree.apple_pay_gateway import ApplePayGateway
 from braintree.braintree_gateway import BraintreeGateway
 from braintree.client_token import ClientToken
 from braintree.configuration import Configuration

--- a/braintree/apple_pay_gateway.py
+++ b/braintree/apple_pay_gateway.py
@@ -22,8 +22,6 @@ class ApplePayGateway(object):
         self.config.http().delete(self.config.base_merchant_path() + "/processing/apple_pay/unregister_domain?url=" + cgi.escape(domain))
         return SuccessfulResult()
 
-        return ErrorResult(self.gateway, 'An unexpected error occurred.')
-
     def registered_domains(self):
         response = self.config.http().get(self.config.base_merchant_path() + "/processing/apple_pay/registered_domains")
 

--- a/braintree/apple_pay_gateway.py
+++ b/braintree/apple_pay_gateway.py
@@ -1,0 +1,33 @@
+import cgi
+
+from braintree.error_result import ErrorResult
+from braintree.successful_result import SuccessfulResult
+from braintree.exceptions.unexpected_error import UnexpectedError
+
+
+class ApplePayGateway(object):
+    def __init__(self, gateway):
+        self.gateway = gateway
+        self.config = gateway.config
+
+    def register_domain(self, domain):
+        response = self.config.http().post(self.config.base_merchant_path() + "/processing/apple_pay/validate_domains", {'url': domain})
+
+        if "response" in response and response["response"]["success"]:
+            return SuccessfulResult()
+        elif response["api_error_response"]:
+            return ErrorResult(self.gateway, response["api_error_response"])
+
+    def unregister_domain(self, domain):
+        self.config.http().delete(self.config.base_merchant_path() + "/processing/apple_pay/unregister_domain?url=" + cgi.escape(domain))
+        return SuccessfulResult()
+
+        return ErrorResult(self.gateway, 'An unexpected error occurred.')
+
+    def registered_domains(self):
+        response = self.config.http().get(self.config.base_merchant_path() + "/processing/apple_pay/registered_domains")
+
+        if "response" in response:
+            response = response["response"]
+
+        return response["domains"]

--- a/braintree/braintree_gateway.py
+++ b/braintree/braintree_gateway.py
@@ -1,5 +1,6 @@
 from braintree.add_on_gateway import AddOnGateway
 from braintree.address_gateway import AddressGateway
+from braintree.apple_pay_gateway import ApplePayGateway
 from braintree.client_token_gateway import ClientTokenGateway
 from braintree.configuration import Configuration
 from braintree.credit_card_gateway import CreditCardGateway
@@ -44,6 +45,7 @@ class BraintreeGateway(object):
         self.graphql_client = self.config.graphql_client()
         self.add_on = AddOnGateway(self)
         self.address = AddressGateway(self)
+        self.apple_pay = ApplePayGateway(self)
         self.client_token = ClientTokenGateway(self)
         self.credit_card = CreditCardGateway(self)
         self.customer = CustomerGateway(self)

--- a/braintree/util/http.py
+++ b/braintree/util/http.py
@@ -31,7 +31,7 @@ class Http(object):
 
     @staticmethod
     def is_error_status(status):
-        return status not in [200, 201, 422]
+        return status not in [200, 201, 204, 422]
 
     @staticmethod
     def raise_exception_from_status(status, message=None):

--- a/tests/unit/test_apple_pay_gateway.py
+++ b/tests/unit/test_apple_pay_gateway.py
@@ -1,0 +1,30 @@
+from tests.test_helper import *
+from braintree.apple_pay_gateway import ApplePayGateway
+if sys.version_info[0] == 2:
+    from mock import MagicMock
+else:
+    from unittest.mock import MagicMock
+
+
+class TestApplePayGateway(unittest.TestCase):
+    def test_registered_domains(self):
+        apple_pay_gateway, http_mock = self.setup_apple_pay_gateway_and_mock_http()
+        apple_pay_gateway.registered_domains()
+        self.assertTrue("get('/merchants/integration_merchant_id/processing/apple_pay/registered_domains')" in str(http_mock.mock_calls))
+
+    def test_register_domain(self):
+        apple_pay_gateway, http_mock = self.setup_apple_pay_gateway_and_mock_http()
+        apple_pay_gateway.register_domain('test.example.com')
+        self.assertTrue("post('/merchants/integration_merchant_id/processing/apple_pay/validate_domains', {'url': 'test.example.com'})" in str(http_mock.mock_calls))
+
+    def test_unregister_domain(self):
+        apple_pay_gateway, http_mock = self.setup_apple_pay_gateway_and_mock_http()
+        apple_pay_gateway.unregister_domain('test.example.com')
+        self.assertTrue("delete('/merchants/integration_merchant_id/processing/apple_pay/unregister_domain?url=test.example.com')" in str(http_mock.mock_calls))
+
+    def setup_apple_pay_gateway_and_mock_http(self):
+        braintree_gateway = BraintreeGateway(Configuration.instantiate())
+        apple_pay_gateway = ApplePayGateway(braintree_gateway)
+        http_mock = MagicMock(name='config.http')
+        braintree_gateway.config.http = http_mock
+        return apple_pay_gateway, http_mock


### PR DESCRIPTION
# Summary
- Add ApplePayGateway, with registered_domains(), register_domain() and unregister_domain() method support.
- Update HTTP to mark 204 as a success HTTP code
- Add tests for mock requests

# Checklist

- [x] Added changelog entry
- [x] Ran unit tests (`nosetests tests/unit`)
