### PR TITLE
Remove usage of mutable objects as default parameters #113

### DIFF
--- a/braintree/address.py
+++ b/braintree/address.py
@@ -47,7 +47,7 @@ class Address(Resource):
 
 
     @staticmethod
-    def create(params={}):
+    def create(params=None):
         """
         Create an Address.
 
@@ -61,7 +61,8 @@ class Address(Resource):
             })
 
         """
-
+        if params is None:
+            params = {}
         return Configuration.gateway().address.create(params)
 
     @staticmethod
@@ -89,7 +90,7 @@ class Address(Resource):
         return Configuration.gateway().address.find(customer_id, address_id)
 
     @staticmethod
-    def update(customer_id, address_id, params={}):
+    def update(customer_id, address_id, params=None):
         """
         Update an existing Address.
 
@@ -100,7 +101,8 @@ class Address(Resource):
             })
 
         """
-
+        if params is None:
+            params = {}
         return Configuration.gateway().address.update(customer_id, address_id, params)
 
     @staticmethod

--- a/braintree/address_gateway.py
+++ b/braintree/address_gateway.py
@@ -11,11 +11,13 @@ class AddressGateway(object):
         self.gateway = gateway
         self.config = gateway.config
 
-    def create(self, params={}):
+    def create(self, params=None):
+        if params is None:
+            params = {}
         Resource.verify_keys(params, Address.create_signature())
-        if not "customer_id" in params:
+        if "customer_id" not in params:
             raise KeyError("customer_id must be provided")
-        if not re.search("\A[0-9A-Za-z_-]+\Z", params["customer_id"]):
+        if not re.search(r"\A[0-9A-Za-z_-]+\Z", params["customer_id"]):
             raise KeyError("customer_id contains invalid characters")
 
         response = self.config.http().post(self.config.base_merchant_path() + "/customers/" + params.pop("customer_id") + "/addresses", {"address": params})
@@ -37,7 +39,9 @@ class AddressGateway(object):
         except NotFoundError:
             raise NotFoundError("address for customer " + repr(customer_id) + " with id " + repr(address_id) + " not found")
 
-    def update(self, customer_id, address_id, params={}):
+    def update(self, customer_id, address_id, params=None):
+        if params is None:
+            params = {}
         Resource.verify_keys(params, Address.update_signature())
         response = self.config.http().put(
             self.config.base_merchant_path() + "/customers/" + customer_id + "/addresses/" + address_id,
@@ -47,4 +51,3 @@ class AddressGateway(object):
             return SuccessfulResult({"address": Address(self.gateway, response["address"])})
         elif "api_error_response" in response:
             return ErrorResult(self.gateway, response["api_error_response"])
-

--- a/braintree/attribute_getter.py
+++ b/braintree/attribute_getter.py
@@ -1,19 +1,21 @@
 class AttributeGetter(object):
     """
-    Helper class for objects that define their attributes from dictionaries 
+    Helper class for objects that define their attributes from dictionaries
     passed in during instantiation.
-    
+
     Example:
-    
+
     a = AttributeGetter({'foo': 'bar', 'baz': 5})
     a.foo
     >> 'bar'
     a.baz
     >> 5
-    
+
     Typically inherited by subclasses instead of directly instantiated.
     """
-    def __init__(self, attributes={}):
+    def __init__(self, attributes=None):
+        if attributes is None:
+            attributes = {}
         self._setattrs = []
         for key, val in attributes.items():
             setattr(self, key, val)

--- a/braintree/client_token.py
+++ b/braintree/client_token.py
@@ -9,7 +9,9 @@ from braintree import exceptions
 class ClientToken(object):
 
     @staticmethod
-    def generate(params={}, gateway=None):
+    def generate(params=None, gateway=None):
+        if params is None:
+            params = {}
         if gateway is None:
             gateway = Configuration.gateway().client_token
 

--- a/braintree/client_token_gateway.py
+++ b/braintree/client_token_gateway.py
@@ -9,8 +9,10 @@ class ClientTokenGateway(object):
         self.config = gateway.config
 
 
-    def generate(self, params={}):
-        if "options" in params and not "customer_id" in params:
+    def generate(self, params=None):
+        if params is None:
+            params = {}
+        if "options" in params and "customer_id" not in params:
             for option in ["verify_card", "make_default", "fail_on_duplicate_payment_method"]:
                 if option in params["options"]:
                     raise exceptions.InvalidSignatureError("cannot specify %s without a customer_id" % option)

--- a/braintree/credit_card.py
+++ b/braintree/credit_card.py
@@ -123,7 +123,7 @@ class CreditCard(Resource):
         return Configuration.gateway().credit_card.confirm_transparent_redirect(query_string)
 
     @staticmethod
-    def create(params={}):
+    def create(params=None):
         """
         Create a CreditCard.
 
@@ -135,11 +135,12 @@ class CreditCard(Resource):
             })
 
         """
-
+        if params is None:
+            params = {}
         return Configuration.gateway().credit_card.create(params)
 
     @staticmethod
-    def update(credit_card_token, params={}):
+    def update(credit_card_token, params=None):
         """
         Update an existing CreditCard
 
@@ -150,7 +151,8 @@ class CreditCard(Resource):
             })
 
         """
-
+        if params is None:
+            params = {}
         return Configuration.gateway().credit_card.update(credit_card_token, params)
 
     @staticmethod
@@ -339,4 +341,3 @@ class CreditCard(Resource):
         Returns the masked number of the CreditCard.
         """
         return self.bin + "******" + self.last_4
-

--- a/braintree/credit_card.py
+++ b/braintree/credit_card.py
@@ -217,7 +217,7 @@ class CreditCard(Resource):
         return CreditCard.signature("update")
 
     @staticmethod
-    def signature(type_):
+    def signature(type):
         billing_address_params = [
             "company",
             "country_code_alpha2",
@@ -271,11 +271,11 @@ class CreditCard(Resource):
             }
         ]
 
-        if type_ == "create":
+        if type == "create":
             signature.append("customer_id")
-        elif type_ == "update":
+        elif type == "update":
             billing_address_params.append({"options": ["update_existing"]})
-        elif type_ == "update_via_customer":
+        elif type == "update_via_customer":
             options.append("update_existing_token")
             billing_address_params.append({"options": ["update_existing"]})
         else:

--- a/braintree/credit_card.py
+++ b/braintree/credit_card.py
@@ -215,7 +215,7 @@ class CreditCard(Resource):
         return CreditCard.signature("update")
 
     @staticmethod
-    def signature(type):
+    def signature(type_):
         billing_address_params = [
             "company",
             "country_code_alpha2",
@@ -269,11 +269,11 @@ class CreditCard(Resource):
             }
         ]
 
-        if type == "create":
+        if type_ == "create":
             signature.append("customer_id")
-        elif type == "update":
+        elif type_ == "update":
             billing_address_params.append({"options": ["update_existing"]})
-        elif type == "update_via_customer":
+        elif type_ == "update_via_customer":
             options.append("update_existing_token")
             billing_address_params.append({"options": ["update_existing"]})
         else:

--- a/braintree/credit_card_gateway.py
+++ b/braintree/credit_card_gateway.py
@@ -14,10 +14,12 @@ class CreditCardGateway(object):
         self.config = gateway.config
 
     def confirm_transparent_redirect(self, query_string):
-        id = self.gateway.transparent_redirect._parse_and_validate_query_string(query_string)["id"][0]
-        return self._post("/payment_methods/all/confirm_transparent_redirect_request", {"id": id})
+        id_ = self.gateway.transparent_redirect._parse_and_validate_query_string(query_string)["id"][0]
+        return self._post("/payment_methods/all/confirm_transparent_redirect_request", {"id": id_})
 
-    def create(self, params={}):
+    def create(self, params=None):
+        if params is None:
+            params = {}
         Resource.verify_keys(params, CreditCard.create_signature())
         return self._post("/payment_methods", {"credit_card": params})
 
@@ -73,7 +75,9 @@ class CreditCardGateway(object):
     def transparent_redirect_update_url(self):
         return self.config.base_url() + self.config.base_merchant_path() + "/payment_methods/all/update_via_transparent_redirect_request"
 
-    def update(self, credit_card_token, params={}):
+    def update(self, credit_card_token, params=None):
+        if params is None:
+            params = {}
         Resource.verify_keys(params, CreditCard.update_signature())
         response = self.config.http().put(self.config.base_merchant_path() + "/payment_methods/credit_card/" + credit_card_token, {"credit_card": params})
         if "credit_card" in response:
@@ -93,10 +97,11 @@ class CreditCardGateway(object):
         response = self.config.http().post(self.config.base_merchant_path() + "/payment_methods/all/expiring?" + query, {"search": criteria})
         return [CreditCard(self.gateway, item) for item in ResourceCollection._extract_as_array(response["payment_methods"], "credit_card")]
 
-    def _post(self, url, params={}):
+    def _post(self, url, params=None):
+        if params is None:
+            params = {}
         response = self.config.http().post(self.config.base_merchant_path() + url, params)
         if "credit_card" in response:
             return SuccessfulResult({"credit_card": CreditCard(self.gateway, response["credit_card"])})
         elif "api_error_response" in response:
             return ErrorResult(self.gateway, response["api_error_response"])
-

--- a/braintree/credit_card_verification_gateway.py
+++ b/braintree/credit_card_verification_gateway.py
@@ -51,8 +51,8 @@ class CreditCardVerificationGateway(object):
         return [CreditCardVerification(self.gateway, item) for item in ResourceCollection._extract_as_array(response["credit_card_verifications"], "verification")]
 
     def create(self, params):
-       response = self.config.http().post(self.config.base_merchant_path() + "/verifications", {"verification": params})
-       if "verification" in response:
-           return SuccessfulResult({"verification": CreditCardVerification(self.gateway, response["verification"])})
-       elif "api_error_response" in response:
-           return ErrorResult(self.gateway, response["api_error_response"])
+        response = self.config.http().post(self.config.base_merchant_path() + "/verifications", {"verification": params})
+        if "verification" in response:
+            return SuccessfulResult({"verification": CreditCardVerification(self.gateway, response["verification"])})
+        elif "api_error_response" in response:
+            return ErrorResult(self.gateway, response["api_error_response"])

--- a/braintree/customer.py
+++ b/braintree/customer.py
@@ -107,7 +107,7 @@ class Customer(Resource):
         return Configuration.gateway().customer.confirm_transparent_redirect(query_string)
 
     @staticmethod
-    def create(params={}):
+    def create(params=None):
         """
         Create a Customer
 
@@ -119,7 +119,8 @@ class Customer(Resource):
             })
 
         """
-
+        if params is None:
+            params = {}
         return Configuration.gateway().customer.create(params)
 
     @staticmethod
@@ -178,7 +179,7 @@ class Customer(Resource):
         return Configuration.gateway().customer.transparent_redirect_update_url()
 
     @staticmethod
-    def update(customer_id, params={}):
+    def update(customer_id, params=None):
         """
         Update an existing Customer
 
@@ -189,7 +190,8 @@ class Customer(Resource):
             })
 
         """
-
+        if params is None:
+            params = {}
         return Configuration.gateway().customer.update(customer_id, params)
 
     @staticmethod

--- a/braintree/customer_gateway.py
+++ b/braintree/customer_gateway.py
@@ -18,10 +18,12 @@ class CustomerGateway(object):
         return ResourceCollection({}, response, self.__fetch)
 
     def confirm_transparent_redirect(self, query_string):
-        id = self.gateway.transparent_redirect._parse_and_validate_query_string(query_string)["id"][0]
-        return self._post("/customers/all/confirm_transparent_redirect_request", {"id": id})
+        id_ = self.gateway.transparent_redirect._parse_and_validate_query_string(query_string)["id"][0]
+        return self._post("/customers/all/confirm_transparent_redirect_request", {"id": id_})
 
-    def create(self, params={}):
+    def create(self, params=None):
+        if params is None:
+            params = {}
         Resource.verify_keys(params, Customer.create_signature())
         return self._post("/customers", {"customer": params})
 
@@ -66,7 +68,9 @@ class CustomerGateway(object):
     def transparent_redirect_update_url(self):
         return self.config.base_url() + self.config.base_merchant_path() + "/customers/all/update_via_transparent_redirect_request"
 
-    def update(self, customer_id, params={}):
+    def update(self, customer_id, params=None):
+        if params is None:
+            params = {}
         Resource.verify_keys(params, Customer.update_signature())
         response = self.config.http().put(self.config.base_merchant_path() + "/customers/" + customer_id, {"customer": params})
         if "customer" in response:
@@ -89,7 +93,9 @@ class CustomerGateway(object):
         response = self.config.http().post(self.config.base_merchant_path() + "/customers/advanced_search", {"search": criteria})
         return [Customer(self.gateway, item) for item in ResourceCollection._extract_as_array(response["customers"], "customer")]
 
-    def _post(self, url, params={}):
+    def _post(self, url, params=None):
+        if params is None:
+            params = {}
         response = self.config.http().post(self.config.base_merchant_path() + url, params)
         if "customer" in response:
             return SuccessfulResult({"customer": Customer(self.gateway, response["customer"])})
@@ -97,4 +103,3 @@ class CustomerGateway(object):
             return ErrorResult(self.gateway, response["api_error_response"])
         else:
             pass
-

--- a/braintree/document_upload.py
+++ b/braintree/document_upload.py
@@ -24,7 +24,7 @@ class DocumentUpload(Resource):
         EvidenceDocument = "evidence_document"
 
     @staticmethod
-    def create(params={}):
+    def create(params=None):
         """
         Create a DocumentUpload
 
@@ -38,6 +38,8 @@ class DocumentUpload(Resource):
             )
 
         """
+        if params is None:
+            params = {}
         return Configuration.gateway().document_upload.create(params)
 
     @staticmethod

--- a/braintree/document_upload_gateway.py
+++ b/braintree/document_upload_gateway.py
@@ -10,7 +10,9 @@ class DocumentUploadGateway(object):
         self.gateway = gateway
         self.config = gateway.config
 
-    def create(self, params={}):
+    def create(self, params=None):
+        if params is None:
+            params = {}
         Resource.verify_keys(params, DocumentUpload.create_signature())
 
         if "file" in params and not hasattr(params["file"], "read"):

--- a/braintree/merchant_account/merchant_account.py
+++ b/braintree/merchant_account/merchant_account.py
@@ -37,7 +37,9 @@ class MerchantAccount(Resource):
         return super(MerchantAccount, self).__repr__(detail_list)
 
     @staticmethod
-    def create(params={}):
+    def create(params=None):
+        if params is None:
+            params = {}
         return Configuration.gateway().merchant_account.create(params)
 
     @staticmethod

--- a/braintree/merchant_account_gateway.py
+++ b/braintree/merchant_account_gateway.py
@@ -12,11 +12,15 @@ class MerchantAccountGateway(object):
         self.gateway = gateway
         self.config = gateway.config
 
-    def create(self, params={}):
+    def create(self, params=None):
+        if params is None:
+            params = {}
         Resource.verify_keys(params, MerchantAccountGateway._detect_signature(params))
         return self._post("/merchant_accounts/create_via_api", {"merchant_account": params})
 
-    def update(self, merchant_account_id, params={}):
+    def update(self, merchant_account_id, params=None):
+        if params is None:
+            params = {}
         Resource.verify_keys(params, MerchantAccountGateway._update_signature())
         return self._put("/merchant_accounts/%s/update_via_api" % merchant_account_id, {"merchant_account": params})
 
@@ -29,7 +33,9 @@ class MerchantAccountGateway(object):
         except NotFoundError:
             raise NotFoundError("merchant account with id " + repr(merchant_account_id) + " not found")
 
-    def create_for_currency(self, params={}):
+    def create_for_currency(self, params=None):
+        if params is None:
+            params = {}
         return self._post("/merchant_accounts/create_for_currency", {"merchant_account": params})
 
     def all(self):
@@ -42,7 +48,9 @@ class MerchantAccountGateway(object):
         merchant_accounts = [MerchantAccount(self.gateway, merchant_account) for merchant_account in ResourceCollection._extract_as_array(body, "merchant_account")]
         return PaginatedResult(body["total_items"], body["page_size"], merchant_accounts)
 
-    def _post(self, url, params={}):
+    def _post(self, url, params=None):
+        if params is None:
+            params = {}
         response = self.config.http().post(self.config.base_merchant_path() + url, params)
 
         if "response" in response:
@@ -53,7 +61,9 @@ class MerchantAccountGateway(object):
         elif "api_error_response" in response:
             return ErrorResult(self.gateway, response["api_error_response"])
 
-    def _put(self, url, params={}):
+    def _put(self, url, params=None):
+        if params is None:
+            params = {}
         response = self.config.http().put(self.config.base_merchant_path() + url, params)
         if "merchant_account" in response:
             return SuccessfulResult({"merchant_account": MerchantAccount(self.gateway, response["merchant_account"])})

--- a/braintree/merchant_gateway.py
+++ b/braintree/merchant_gateway.py
@@ -14,7 +14,9 @@ class MerchantGateway(object):
     def create(self, params):
         return self.__create_merchant(params)
 
-    def __create_merchant(self, params={}):
+    def __create_merchant(self, params=None):
+        if params is None:
+            params = {}
         response = self.config.http().post("/merchants/create_via_api", {
             "merchant": params
         })

--- a/braintree/payment_method.py
+++ b/braintree/payment_method.py
@@ -5,7 +5,9 @@ from braintree.configuration import Configuration
 
 class PaymentMethod(Resource):
     @staticmethod
-    def create(params={}):
+    def create(params=None):
+        if params is None:
+            params = {}
         return Configuration.gateway().payment_method.create(params)
 
     @staticmethod
@@ -17,7 +19,9 @@ class PaymentMethod(Resource):
         return Configuration.gateway().payment_method.update(payment_method_token, params)
 
     @staticmethod
-    def delete(payment_method_token, options={}):
+    def delete(payment_method_token, options=None):
+        if options is None:
+            options = {}
         return Configuration.gateway().payment_method.delete(payment_method_token, options)
 
     @staticmethod

--- a/braintree/payment_method_gateway.py
+++ b/braintree/payment_method_gateway.py
@@ -33,7 +33,9 @@ class PaymentMethodGateway(object):
         self.gateway = gateway
         self.config = gateway.config
 
-    def create(self, params={}):
+    def create(self, params=None):
+        if params is None:
+            params = {}
         Resource.verify_keys(params, PaymentMethod.create_signature())
         return self._post("/payment_methods", {"payment_method": params})
 
@@ -60,7 +62,9 @@ class PaymentMethodGateway(object):
         except NotFoundError:
             raise NotFoundError("payment method with token " + repr(payment_method_token) + " not found")
 
-    def delete(self, payment_method_token, options={}):
+    def delete(self, payment_method_token, options=None):
+        if options is None:
+            options = {}
         Resource.verify_keys(options, PaymentMethod.delete_signature())
         query_param = ""
         if options:
@@ -114,7 +118,9 @@ class PaymentMethodGateway(object):
         except NotFoundError:
             raise NotFoundError("payment method with payment_method_token " + repr(payment_method_token) + " not found")
 
-    def _post(self, url, params={}, result_key="payment_method"):
+    def _post(self, url, params=None, result_key="payment_method"):
+        if params is None:
+            params = {}
         response = self.config.http().post(self.config.base_merchant_path() + url, params)
         if "api_error_response" in response:
             return ErrorResult(self.gateway, response["api_error_response"])
@@ -128,7 +134,9 @@ class PaymentMethodGateway(object):
             return SuccessfulResult({result_key: payment_method})
         return response
 
-    def _put(self, url, params={}):
+    def _put(self, url, params=None):
+        if params is None:
+            params = {}
         response = self.config.http().put(self.config.base_merchant_path() + url, params)
         if "api_error_response" in response:
             return ErrorResult(self.gateway, response["api_error_response"])

--- a/braintree/paypal_account.py
+++ b/braintree/paypal_account.py
@@ -12,7 +12,9 @@ class PayPalAccount(Resource):
         return Configuration.gateway().paypal_account.delete(paypal_account_token)
 
     @staticmethod
-    def update(paypal_account_token, params={}):
+    def update(paypal_account_token, params=None):
+        if params is None:
+            params = {}
         return Configuration.gateway().paypal_account.update(paypal_account_token, params)
 
     @staticmethod

--- a/braintree/paypal_account_gateway.py
+++ b/braintree/paypal_account_gateway.py
@@ -25,7 +25,9 @@ class PayPalAccountGateway(object):
         self.config.http().delete(self.config.base_merchant_path() + "/payment_methods/paypal_account/" + paypal_account_token)
         return SuccessfulResult()
 
-    def update(self, paypal_account_token, params={}):
+    def update(self, paypal_account_token, params=None):
+        if params is None:
+            params = {}
         Resource.verify_keys(params, PayPalAccount.signature())
         response = self.config.http().put(self.config.base_merchant_path() + "/payment_methods/paypal_account/" + paypal_account_token, {"paypal_account": params})
         if "paypal_account" in response:

--- a/braintree/subscription.py
+++ b/braintree/subscription.py
@@ -70,7 +70,7 @@ class Subscription(Resource):
         Pending = "Pending"
 
     @staticmethod
-    def create(params={}):
+    def create(params=None):
         """
         Create a Subscription
 
@@ -82,7 +82,8 @@ class Subscription(Resource):
             })
 
         """
-
+        if params is None:
+            params = {}
         return Configuration.gateway().subscription.create(params)
 
     @staticmethod
@@ -108,8 +109,8 @@ class Subscription(Resource):
                 "options": [
                     "do_not_inherit_add_ons_or_discounts",
                     "start_immediately",
-                    { 
-                        "paypal": [ "description" ] 
+                    {
+                        "paypal": [ "description" ]
                     }
                 ]
             }
@@ -137,7 +138,7 @@ class Subscription(Resource):
         return Configuration.gateway().subscription.retry_charge(subscription_id, amount, submit_for_settlement)
 
     @staticmethod
-    def update(subscription_id, params={}):
+    def update(subscription_id, params=None):
         """
         Update an existing subscription
 
@@ -149,7 +150,8 @@ class Subscription(Resource):
             })
 
         """
-
+        if params is None:
+            params = {}
         return Configuration.gateway().subscription.update(subscription_id, params)
 
     @staticmethod
@@ -203,9 +205,9 @@ class Subscription(Resource):
                 "descriptor": [ "name", "phone", "url" ]
             },
             {
-                "options": [ 
-                    "prorate_charges", 
-                    "replace_all_add_ons_and_discounts", 
+                "options": [
+                    "prorate_charges",
+                    "replace_all_add_ons_and_discounts",
                     "revert_subscription_on_proration_failure",
                     {
                         "paypal": [ "description" ]
@@ -247,7 +249,7 @@ class Subscription(Resource):
         if "descriptor" in attributes:
             self.descriptor = Descriptor(gateway, attributes.pop("descriptor"))
         if "description" in attributes:
-            self.description = attributes["description"] 
+            self.description = attributes["description"]
         if "discounts" in attributes:
             self.discounts = [Discount(gateway, discount) for discount in self.discounts]
         if "status_history" in attributes:

--- a/braintree/subscription_gateway.py
+++ b/braintree/subscription_gateway.py
@@ -20,7 +20,9 @@ class SubscriptionGateway(object):
         elif "api_error_response" in response:
             return ErrorResult(self.gateway, response["api_error_response"])
 
-    def create(self, params={}):
+    def create(self, params=None):
+        if params is None:
+            params = {}
         Resource.verify_keys(params, Subscription.create_signature())
         response = self.config.http().post(self.config.base_merchant_path() + "/subscriptions", {"subscription": params})
         if "subscription" in response:
@@ -56,7 +58,9 @@ class SubscriptionGateway(object):
         response = self.config.http().post(self.config.base_merchant_path() + "/subscriptions/advanced_search_ids", {"search": self.__criteria(query)})
         return ResourceCollection(query, response, self.__fetch)
 
-    def update(self, subscription_id, params={}):
+    def update(self, subscription_id, params=None):
+        if params is None:
+            params = {}
         Resource.verify_keys(params, Subscription.update_signature())
         response = self.config.http().put(self.config.base_merchant_path() + "/subscriptions/" + subscription_id, {"subscription": params})
         if "subscription" in response:
@@ -78,4 +82,3 @@ class SubscriptionGateway(object):
         criteria["ids"] = braintree.subscription_search.SubscriptionSearch.ids.in_list(ids).to_param()
         response = self.config.http().post(self.config.base_merchant_path() + "/subscriptions/advanced_search", {"search": criteria})
         return [Subscription(self.gateway, item) for item in ResourceCollection._extract_as_array(response["subscriptions"], "subscription")]
-

--- a/braintree/transaction.py
+++ b/braintree/transaction.py
@@ -299,7 +299,7 @@ class Transaction(Resource):
         return Configuration.gateway().transaction.confirm_transparent_redirect(query_string)
 
     @staticmethod
-    def credit(params={}):
+    def credit(params=None):
         """
         Creates a transaction of type Credit.
 
@@ -325,7 +325,8 @@ class Transaction(Resource):
             })
 
         """
-
+        if params is None:
+            params = {}
         params["type"] = Transaction.Type.Credit
         return Transaction.create(params)
 
@@ -375,7 +376,7 @@ class Transaction(Resource):
 
 
     @staticmethod
-    def sale(params={}):
+    def sale(params=None):
         """
         Creates a transaction of type Sale. Amount is required. Also, a credit card,
         customer_id or payment_method_token is required. ::
@@ -398,7 +399,8 @@ class Transaction(Resource):
                 "customer_id": "my_customer_id"
             })
         """
-
+        if params is None:
+            params = {}
         params["type"] = Transaction.Type.Sale
         return Transaction.create(params)
 
@@ -420,7 +422,7 @@ class Transaction(Resource):
         return Configuration.gateway().transaction.release_from_escrow(transaction_id)
 
     @staticmethod
-    def submit_for_settlement(transaction_id, amount=None, params={}):
+    def submit_for_settlement(transaction_id, amount=None, params=None):
         """
         Submits an authorized transaction for settlement.
 
@@ -429,11 +431,12 @@ class Transaction(Resource):
             result = braintree.Transaction.submit_for_settlement("my_transaction_id")
 
         """
-
+        if params is None:
+            params = {}
         return Configuration.gateway().transaction.submit_for_settlement(transaction_id, amount, params)
 
     @staticmethod
-    def update_details(transaction_id, params={}):
+    def update_details(transaction_id, params=None):
         """
         Updates exisiting details for transaction submtted_for_settlement.
 
@@ -450,7 +453,8 @@ class Transaction(Resource):
             )
 
         """
-
+        if params is None:
+            params = {}
         return Configuration.gateway().transaction.update_details(transaction_id, params)
 
     @staticmethod
@@ -685,7 +689,7 @@ class Transaction(Resource):
         return ["amount", "order_id"]
 
     @staticmethod
-    def submit_for_partial_settlement(transaction_id, amount, params={}):
+    def submit_for_partial_settlement(transaction_id, amount, params=None):
         """
         Creates a partial settlement transaction for an authorized transaction
 
@@ -694,7 +698,8 @@ class Transaction(Resource):
             result = braintree.Transaction.submit_for_partial_settlement("my_transaction_id", "20.00")
 
         """
-
+        if params is None:
+            params = {}
         return Configuration.gateway().transaction.submit_for_partial_settlement(transaction_id, amount, params)
 
     def __init__(self, gateway, attributes):
@@ -818,7 +823,7 @@ class Transaction(Resource):
 
     @property
     def is_disbursed(self):
-       return self.disbursement_details.is_valid
+        return self.disbursement_details.is_valid
 
     @property
     def line_items(self):

--- a/braintree/transaction_gateway.py
+++ b/braintree/transaction_gateway.py
@@ -25,8 +25,8 @@ class TransactionGateway(object):
             return ErrorResult(self.gateway, response["api_error_response"])
 
     def confirm_transparent_redirect(self, query_string):
-        id = self.gateway.transparent_redirect._parse_and_validate_query_string(query_string)["id"][0]
-        return self._post("/transactions/all/confirm_transparent_redirect_request", {"id": id})
+        id_ = self.gateway.transparent_redirect._parse_and_validate_query_string(query_string)["id"][0]
+        return self._post("/transactions/all/confirm_transparent_redirect_request", {"id": id_})
 
     def create(self, params):
         Resource.verify_keys(params, Transaction.create_signature())
@@ -94,7 +94,9 @@ class TransactionGateway(object):
         elif "api_error_response" in response:
             return ErrorResult(self.gateway, response["api_error_response"])
 
-    def submit_for_settlement(self, transaction_id, amount=None, params={}):
+    def submit_for_settlement(self, transaction_id, amount=None, params=None):
+        if params is None:
+            params = {}
         Resource.verify_keys(params, Transaction.submit_for_settlement_signature())
         transaction_params = {"amount": amount}
         transaction_params.update(params)
@@ -105,7 +107,9 @@ class TransactionGateway(object):
         elif "api_error_response" in response:
             return ErrorResult(self.gateway, response["api_error_response"])
 
-    def update_details(self, transaction_id, params={}):
+    def update_details(self, transaction_id, params=None):
+        if params is None:
+            params = {}
         Resource.verify_keys(params, Transaction.update_details_signature())
         response = self.config.http().put(self.config.base_merchant_path() + "/transactions/" + transaction_id + "/update_details",
                 {"transaction": params})
@@ -114,7 +118,9 @@ class TransactionGateway(object):
         elif "api_error_response" in response:
             return ErrorResult(self.gateway, response["api_error_response"])
 
-    def submit_for_partial_settlement(self, transaction_id, amount, params={}):
+    def submit_for_partial_settlement(self, transaction_id, amount, params=None):
+        if params is None:
+            params = {}
         Resource.verify_keys(params, Transaction.submit_for_settlement_signature())
         transaction_params = {"amount": amount}
         transaction_params.update(params)
@@ -169,10 +175,11 @@ class TransactionGateway(object):
                 criteria[term.name] = term.to_param()
         return criteria
 
-    def _post(self, url, params={}):
+    def _post(self, url, params=None):
+        if params is None:
+            params = {}
         response = self.config.http().post(self.config.base_merchant_path() + url, params)
         if "transaction" in response:
             return SuccessfulResult({"transaction": Transaction(self.gateway, response["transaction"])})
         elif "api_error_response" in response:
             return ErrorResult(self.gateway, response["api_error_response"])
-

--- a/braintree/validation_error_collection.py
+++ b/braintree/validation_error_collection.py
@@ -8,7 +8,9 @@ class ValidationErrorCollection(object):
 
     """
 
-    def __init__(self, data={"errors": []}):
+    def __init__(self, data=None):
+        if data is None:
+            data = {"errors": []}
         self.data = data
 
     @property
@@ -87,7 +89,7 @@ class ValidationErrorCollection(object):
     def __nested_errors(self):
         nested_errors = {}
         for key in self.data:
-            if key == "errors": continue
+            if key == "errors":
+                continue
             nested_errors[key] = ValidationErrorCollection(self.data[key])
         return nested_errors
-


### PR DESCRIPTION
# Summary

- Removed mutable objects as default parameters and replaced with None.
- Added check for None to initialize default parameter to empty dict.
- Keyword 'id' used as variable name in a function changed to 'id_'.

# Checklist

- [ ] Added changelog entry
- [x] Ran unit tests (`nosetests tests/unit`)

<!-- **For Braintree Developers only, don't forget:**
- [ ] Does this change require work to be done to the GraphQL API? If you have questions check with the GraphQL team.
- [ ] Add & Run integration tests -->
