### PR TITLE
Include tests in release

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include braintree/ssl/*
+recursive-include tests


### PR DESCRIPTION
It will be useful to have the tests included in the release archive published, this will help packager to ensure the package installation is correctly working by executing the tests (see https://bugs.gentoo.org/767256).