### PR TITLE
docs: Fix a few typos

### DIFF
--- a/braintree/exceptions/server_error.py
+++ b/braintree/exceptions/server_error.py
@@ -2,7 +2,7 @@ from braintree.exceptions.braintree_error import BraintreeError
 
 class ServerError(BraintreeError):
     """
-    Raised when the gateway raises an error.  Please contant support at support@getbraintree.com.
+    Raised when the gateway raises an error.  Please contact support at support@getbraintree.com.
 
     See https://developers.braintreepayments.com/reference/general/exceptions/python#server-error
     """

--- a/braintree/subscription.py
+++ b/braintree/subscription.py
@@ -57,7 +57,7 @@ class Subscription(Resource):
     # NEXT_MAJOR_VERSION this can be an enum! they were added as of python 3.4 and we support 3.5+
     class Status(object):
         """
-        Constants representing subscription statusues.  Available statuses are:
+        Constants representing subscription statuses.  Available statuses are:
 
         * braintree.Subscription.Status.Active
         * braintree.Subscription.Status.Canceled
@@ -177,7 +177,7 @@ class Subscription(Resource):
         - status
 
         For text fields, you can search using the following operators: ==, !=, starts_with, ends_with
-        and contains. For mutiple value fields, you can search using the in_list operator. An example::
+        and contains. For multiple value fields, you can search using the in_list operator. An example::
 
             braintree.Subscription.search([
                 braintree.SubscriptionSearch.plan_id.starts_with("abc"),

--- a/braintree/transaction.py
+++ b/braintree/transaction.py
@@ -437,7 +437,7 @@ class Transaction(Resource):
     @staticmethod
     def update_details(transaction_id, params=None):
         """
-        Updates exisiting details for transaction submtted_for_settlement.
+        Updates existing details for transaction submitted_for_settlement.
 
         Requires the transaction id::
 

--- a/braintree/us_bank_account_verification_search.py
+++ b/braintree/us_bank_account_verification_search.py
@@ -29,5 +29,5 @@ class UsBankAccountVerificationSearch:
     # Equality fields
     account_type = Search.EqualityNodeBuilder("account_type")
 
-    # Ends-with fieds
+    # Ends-with fields
     account_number = Search.EndsWithNodeBuilder("account_number")


### PR DESCRIPTION
There are small typos in:
- braintree/exceptions/server_error.py
- braintree/subscription.py
- braintree/transaction.py
- braintree/us_bank_account_verification_search.py

Fixes:
- Should read `submitted` rather than `submtted`.
- Should read `statuses` rather than `statusues`.
- Should read `multiple` rather than `mutiple`.
- Should read `fields` rather than `fieds`.
- Should read `existing` rather than `exisiting`.
- Should read `contact` rather than `contant`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md