### PR TITLE
Fix all instances of anomalous backslashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.16.1
+* Fix `DeprecationWarning` on invalid escape sequences
+
 ## 4.16.0
 * Add `LiabilityShift` class and `liability_shift` to RiskData
 * Add ExchangeRateQuote API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 4.16.1
+## unreleased
 * Fix `DeprecationWarning` on invalid escape sequences
 
 ## 4.16.0

--- a/braintree/resource.py
+++ b/braintree/resource.py
@@ -51,10 +51,14 @@ class Resource(AttributeGetter):
 
     @staticmethod
     def __remove_wildcard_keys(allowed_keys, invalid_keys):
-        wildcard_keys = [re.sub("(?<=[^\\\\])_", "\\_", re.escape(key)).replace("\\[\\_\\_any\\_key\\_\\_\\]", "\\[[\w-]+\\]") for key in allowed_keys if re.search("\\[__any_key__\\]", key)]
+        wildcard_keys = [
+            re.sub(r"(?<=[^\\])_", "\\_", re.escape(key)).replace(r"\[\_\_any\_key\_\_\]", r"\[[\w-]+\]")
+            for key in allowed_keys
+            if re.search(r"\[__any_key__\]", key)
+        ]
         new_keys = []
         for key in invalid_keys:
-            if len([match for match in wildcard_keys if re.match("\A" + match + "\Z", key)]) == 0:
+            if len([match for match in wildcard_keys if re.match(r"\A" + match + r"\Z", key)]) == 0:
                 new_keys.append(key)
         return new_keys
 

--- a/braintree/util/parser.py
+++ b/braintree/util/parser.py
@@ -10,7 +10,7 @@ class Parser(object):
     def __init__(self, xml):
         if isinstance(xml, binary_type):
             xml = xml.decode('utf-8')
-        self.doc = minidom.parseString("><".join(re.split(">\s+<", xml)).strip())
+        self.doc = minidom.parseString("><".join(re.split(r">\s+<", xml)).strip())
 
     def parse(self):
         return {self.__underscored(self.doc.documentElement.tagName): self.__parse_node(self.doc.documentElement)}


### PR DESCRIPTION
Summary
=======
This commit fixes deprecation warnings that arise from using backslashes
in strings, but *not* as part of an escape sequence. It will help this
library be used with newer versions of Python.

Examples
========
Consider the string `'\A'`, previously used in `braintree/resource.py`:

```bash
$ python -Wd -c 'print("\A")'
DeprecationWarning: invalid escape sequence \A
$ python -W error -c 'print("\A")'
SyntaxError: invalid escape sequence \A
```

Explanation
===========
For an explanation of the problem (and the recommended solution),
see: https://docs.python.org/3/library/re.html

>  Also, please note that any invalid escape sequences in Python’s usage
> of the backslash in string literals now generate a DeprecationWarning
> and in the future this will become a SyntaxError. This behaviour will
> happen even if it is a valid escape sequence for a regular expression.
>
> The solution is to use Python’s raw string notation for regular
> expression patterns; backslashes are not handled in any special way in a
> string literal prefixed with 'r'.

There are no functional changes!
================================
The raw strings used here are equivalent to their originals
on all currently supported versions of Python (including EOL Python 3.5,
3.6).

```python  # same on 3.5, 3.6, 3.8, 3.10, etc.
>>> r"(?<=[^\\])_" == "(?<=[^\\\\])_"
True
>>> r"\[\_\_any\_key\_\_\]" == "\\[\\_\\_any\\_key\\_\\_\\]"
True
>>> r"\[__any_key__\]" == "\\[__any_key__\\]"
True
>>> r'\Z' == '\Z'
True
```

----
# Checklist

- [x] Added changelog entry
- [x] Ran unit tests (`nosetests tests/unit`)
- [x] I understand that unless this is a Draft PR or has a DO NOT MERGE label, this PR is considered to be in a deploy ready state and can be deployed if merged to main

<!-- **For Braintree Developers only, don't forget:**
- [ ] Does this change require work to be done to the GraphQL API? If you have questions check with the GraphQL team.
- [ ] Add & Run integration tests -->
