### PR TITLE
Use unittest instead of nose

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 # Checklist
 
 - [ ] Added changelog entry
-- [ ] Ran unit tests (`nosetests tests/unit`)
+- [ ] Ran unit tests (`python3 -m unittest discover tests/unit`)
 - [ ] I understand that unless this is a Draft PR or has a DO NOT MERGE label, this PR is considered to be in a deploy ready state and can be deployed if merged to main
 
 <!-- **For Braintree Developers only, don't forget:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.18.0
+* Replace nose usage for tests with unittest
+* Remove mock dev dependency
+
 ## 4.17.0
 * Fix `DeprecationWarning` on invalid escape sequences (thanks @DavidCain)
 * Add validation for arguments in Address.delete, Address.find, and Address.update
@@ -99,12 +103,12 @@
 
 ## 4.1.0
 * Add `DisputeAccepted`, `DisputeDisputed`, and `DisputeExpired` webhook constants
-* Add `three_d_secure_pass_thru` to `CreditCard.create`, `CreditCard.update`, `PaymentMethod.create`, `PaymentMethod.update`, `Customer.create`, and `Customer.update`. 
+* Add `three_d_secure_pass_thru` to `CreditCard.create`, `CreditCard.update`, `PaymentMethod.create`, `PaymentMethod.update`, `Customer.create`, and `Customer.update`.
 * Add `Verification` validation errors for 3D Secure
 * Add `payment_method_token` to `CreditCardVerificationSearch`
 * Add `recurring_customer_consent` and `recurring_max_amount` to `authentication_insight_options` for `PaymentMethodNonce.create`
 * Add `FileIsEmpty` error code
-* Eliminates usage of mutable objects for function parameters. Resolves #113 Thank you @maneeshd! 
+* Eliminates usage of mutable objects for function parameters. Resolves #113 Thank you @maneeshd!
 
 ## 4.0.0
 * Split development and deployments requirements files out

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ make
 
 Our friends at [Venmo](https://venmo.com) have [an open source library](https://github.com/venmo/btnamespace) designed to simplify testing of applications using this library.
 
-If you wish to run the tests, make sure you are set up for development (see instructions above). The unit specs can be run by anyone on any system, but the integration specs are meant to be run against a local development server of our gateway code. These integration specs are not meant for public consumption and will likely fail if run on your system. To run unit tests use rake (`rake test:unit`) or nose (`nosetests tests/unit`).
+If you wish to run the tests, make sure you are set up for development (see instructions above). The unit specs can be run by anyone on any system, but the integration specs are meant to be run against a local development server of our gateway code. These integration specs are not meant for public consumption and will likely fail if run on your system. To run unit tests use rake (`rake test:unit`) or unittest (`python3 -m unittest discover tests/unit`).
 
 ## License
 

--- a/Rakefile
+++ b/Rakefile
@@ -12,11 +12,11 @@ namespace :test do
   desc "run unit tests"
   task :unit, [:file_name, :test_name] do |task, args|
     if args.file_name.nil?
-      sh "nosetests #{print_stdout} tests/unit"
+      sh "python3 -m unittest discover #{print_stdout} tests/unit"
     elsif args.test_name.nil?
-      sh "nosetests #{print_stdout} tests/unit/#{args.file_name}.py"
+      sh "python3 -m unittest discover #{print_stdout} tests/unit/#{args.file_name}.py"
     else
-      sh "nosetests #{print_stdout} tests/unit/#{args.file_name}.py -m #{args.test_name}"
+      sh "python3 -m unittest discover #{print_stdout} tests/unit/#{args.file_name}.py -m #{args.test_name}"
     end
   end
 
@@ -27,11 +27,11 @@ namespace :test do
   desc "run integration tests"
   task :integration, [:file_name, :test_name] do |task, args|
     if args.file_name.nil?
-      sh "nosetests #{print_stdout} tests/integration"
+      sh "python3 -m unittest discover #{print_stdout} tests/integration"
     elsif args.test_name.nil?
-      sh "nosetests #{print_stdout} tests/integration/#{args.file_name}.py"
+      sh "python3 -m unittest discover #{print_stdout} tests/integration/#{args.file_name}.py"
     else
-      sh "nosetests #{print_stdout} tests/integration/#{args.file_name}.py -m #{args.test_name}"
+      sh "python3 -m unittest discover #{print_stdout} tests/integration/#{args.file_name}.py -m #{args.test_name}"
     end
   end
 

--- a/ci.sh
+++ b/ci.sh
@@ -5,7 +5,7 @@ if [[ "$1" == "http" ]]; then
 fi
 
 if [[ "$1" == "python3" ]]; then
-  /usr/local/lib/python3.3/bin/nosetests-3.3
+  /usr/local/lib/python3.3/bin/python3 -m unittest discover
 else
   env rake $python_tests --trace
 fi

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,3 +1,2 @@
-mock>=2.0,<3.0
 twine>=1.9,<2.0
 -r requirements.txt

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,3 @@
 mock>=2.0,<3.0
-nose>=1.3.7,<2.0
 twine>=1.9,<2.0
 -r requirements.txt

--- a/tests/integration/test_address.py
+++ b/tests/integration/test_address.py
@@ -86,10 +86,10 @@ class TestAddress(unittest.TestCase):
 
         self.assertTrue(result.is_success)
 
-    @raises(NotFoundError)
     def test_delete_with_valid_customer_id_and_non_existing_address(self):
-        customer = Customer.create().customer
-        Address.delete(customer.id, "notreal")
+        with self.assertRaises(NotFoundError):
+            customer = Customer.create().customer
+            Address.delete(customer.id, "notreal")
 
     def test_find_with_valid_customer_id_and_address_id(self):
         customer = Customer.create().customer
@@ -98,10 +98,9 @@ class TestAddress(unittest.TestCase):
 
         self.assertEqual(address.street_address, found_address.street_address)
 
-    @raises_with_regexp(NotFoundError,
-        "address for customer 'notreal' with id 'badaddress' not found")
     def test_find_with_invalid_customer_id_and_address_id(self):
-        Address.find("notreal", "badaddress")
+        with self.assertRaisesRegex(NotFoundError, "address for customer 'notreal' with id 'badaddress' not found"):
+            Address.find("notreal", "badaddress")
 
     def test_update_with_valid_values(self):
         customer = Customer.create().customer
@@ -163,7 +162,7 @@ class TestAddress(unittest.TestCase):
         self.assertEqual(1, len(country_name_errors))
         self.assertEqual(ErrorCodes.Address.CountryNameIsNotAccepted, country_name_errors[0].code)
 
-    @raises(NotFoundError)
     def test_update_raises_not_found_error_if_given_bad_address(self):
-        customer = Customer.create().customer
-        Address.update(customer.id, "notfound", {"street_address": "123 Main St."})
+        with self.assertRaises(NotFoundError):
+            customer = Customer.create().customer
+            Address.update(customer.id, "notfound", {"street_address": "123 Main St."})

--- a/tests/integration/test_client_token.py
+++ b/tests/integration/test_client_token.py
@@ -160,8 +160,8 @@ class TestClientToken(unittest.TestCase):
 
         self.assertEqual(expected_merchant_account_id, merchant_account_id)
 
-    @raises_with_regexp(Exception, "'Invalid keys: merchant_id'")
     def test_required_data_cannot_be_overridden(self):
-        TestHelper.generate_decoded_client_token({
-            "merchant_id": "1234"
-        })
+        with self.assertRaisesRegex(Exception, "'Invalid keys: merchant_id'"):
+            TestHelper.generate_decoded_client_token({
+                "merchant_id": "1234"
+            })

--- a/tests/integration/test_credit_card.py
+++ b/tests/integration/test_credit_card.py
@@ -927,21 +927,21 @@ class TestCreditCard(unittest.TestCase):
         result = CreditCard.delete(credit_card.token)
         self.assertTrue(result.is_success)
 
-    @raises(NotFoundError)
     def test_delete_raises_error_when_deleting_twice(self):
-        customer = Customer.create().customer
-        credit_card = CreditCard.create({
-            "customer_id": customer.id,
-            "number": "4111111111111111",
-            "expiration_date": "05/2014"
-        }).credit_card
+        with self.assertRaises(NotFoundError):
+            customer = Customer.create().customer
+            credit_card = CreditCard.create({
+                "customer_id": customer.id,
+                "number": "4111111111111111",
+                "expiration_date": "05/2014"
+            }).credit_card
 
-        CreditCard.delete(credit_card.token)
-        CreditCard.delete(credit_card.token)
+            CreditCard.delete(credit_card.token)
+            CreditCard.delete(credit_card.token)
 
-    @raises(NotFoundError)
     def test_delete_with_invalid_token(self):
-        CreditCard.delete("notreal")
+        with self.assertRaises(NotFoundError):
+            CreditCard.delete("notreal")
 
     def test_find_with_valid_token(self):
         customer = Customer.create().customer
@@ -984,9 +984,9 @@ class TestCreditCard(unittest.TestCase):
         self.assertEqual(Decimal("1.00"), subscription.price)
         self.assertEqual(credit_card.token, subscription.payment_method_token)
 
-    @raises_with_regexp(NotFoundError, "payment method with token 'bad_token' not found")
     def test_find_with_invalid_token(self):
-        CreditCard.find("bad_token")
+        with self.assertRaisesRegex(NotFoundError, "payment method with token 'bad_token' not found"):
+            CreditCard.find("bad_token")
 
     def test_from_nonce_with_unlocked_nonce(self):
         config = Configuration.instantiate()
@@ -1017,58 +1017,59 @@ class TestCreditCard(unittest.TestCase):
         self.assertEqual(1, len(customer.credit_cards))
         self.assertEqual(customer.credit_cards[0].token, card.token)
 
-    @raises_with_regexp(NotFoundError, "payment method with nonce .* or not found")
     def test_from_nonce_with_unlocked_nonce_pointing_to_shared_card(self):
-        config = Configuration.instantiate()
+        with self.assertRaisesRegex(NotFoundError, "payment method with nonce .* or not found"):
+            config = Configuration.instantiate()
 
-        client_token = TestHelper.generate_decoded_client_token()
-        authorization_fingerprint = json.loads(client_token)["authorizationFingerprint"]
-        http = ClientApiHttp(config, {
-            "authorization_fingerprint": authorization_fingerprint,
-            "shared_customer_identifier": "fake_identifier",
-            "shared_customer_identifier_type": "testing"
-        })
+            client_token = TestHelper.generate_decoded_client_token()
+            authorization_fingerprint = json.loads(client_token)["authorizationFingerprint"]
+            http = ClientApiHttp(config, {
+                "authorization_fingerprint": authorization_fingerprint,
+                "shared_customer_identifier": "fake_identifier",
+                "shared_customer_identifier_type": "testing"
+            })
 
-        status_code, response = http.add_card({
-            "credit_card": {
-                "number": "4111111111111111",
-                "expiration_month": "11",
-                "expiration_year": "2099",
-            },
-            "share": True
-        })
-        self.assertEqual(201, status_code)
-        nonce = json.loads(response)["creditCards"][0]["nonce"]
+            status_code, response = http.add_card({
+                "credit_card": {
+                    "number": "4111111111111111",
+                    "expiration_month": "11",
+                    "expiration_year": "2099",
+                },
+                "share": True
+            })
+            self.assertEqual(201, status_code)
+            nonce = json.loads(response)["creditCards"][0]["nonce"]
 
-        CreditCard.from_nonce(nonce)
+            CreditCard.from_nonce(nonce)
 
-    @raises_with_regexp(NotFoundError, ".* consumed .*")
+
     def test_from_nonce_with_consumed_nonce(self):
-        config = Configuration.instantiate()
-        customer = Customer.create().customer
+        with self.assertRaisesRegex(NotFoundError, ".* consumed .*"):
+            config = Configuration.instantiate()
+            customer = Customer.create().customer
 
-        client_token = TestHelper.generate_decoded_client_token({
-            "customer_id": customer.id,
-        })
-        authorization_fingerprint = json.loads(client_token)["authorizationFingerprint"]
-        http = ClientApiHttp(config, {
-            "authorization_fingerprint": authorization_fingerprint,
-            "shared_customer_identifier": "fake_identifier",
-            "shared_customer_identifier_type": "testing"
-        })
+            client_token = TestHelper.generate_decoded_client_token({
+                "customer_id": customer.id,
+            })
+            authorization_fingerprint = json.loads(client_token)["authorizationFingerprint"]
+            http = ClientApiHttp(config, {
+                "authorization_fingerprint": authorization_fingerprint,
+                "shared_customer_identifier": "fake_identifier",
+                "shared_customer_identifier_type": "testing"
+            })
 
-        status_code, response = http.add_card({
-            "credit_card": {
-                "number": "4111111111111111",
-                "expiration_month": "11",
-                "expiration_year": "2099",
-            }
-        })
-        self.assertEqual(201, status_code)
-        nonce = json.loads(response)["creditCards"][0]["nonce"]
+            status_code, response = http.add_card({
+                "credit_card": {
+                    "number": "4111111111111111",
+                    "expiration_month": "11",
+                    "expiration_year": "2099",
+                }
+            })
+            self.assertEqual(201, status_code)
+            nonce = json.loads(response)["creditCards"][0]["nonce"]
 
-        CreditCard.from_nonce(nonce)
-        CreditCard.from_nonce(nonce)
+            CreditCard.from_nonce(nonce)
+            CreditCard.from_nonce(nonce)
 
     def test_expired_can_iterate_over_all_items(self):
         year = datetime.now().year - 3

--- a/tests/integration/test_customer.py
+++ b/tests/integration/test_customer.py
@@ -801,11 +801,11 @@ class TestCustomer(unittest.TestCase):
 
         self.assertTrue(result.is_success)
 
-    @raises(NotFoundError)
     def test_delete_with_invalid_customer(self):
-        customer = Customer.create().customer
-        Customer.delete(customer.id)
-        Customer.delete(customer.id)
+        with self.assertRaises(NotFoundError):
+            customer = Customer.create().customer
+            Customer.delete(customer.id)
+            Customer.delete(customer.id)
 
     def test_find_with_valid_customer(self):
         customer = Customer.create({
@@ -836,9 +836,9 @@ class TestCustomer(unittest.TestCase):
         self.assertEqual(1, len(found_customer.us_bank_accounts))
         self.assertIsInstance(found_customer.us_bank_accounts[0], UsBankAccount)
 
-    @raises_with_regexp(NotFoundError, "customer with id 'badid' not found")
     def test_find_with_invalid_customer(self):
-        Customer.find("badid")
+        with self.assertRaisesRegex(NotFoundError, "customer with id 'badid' not found"):
+            Customer.find("badid")
 
     def test_find_customer_with_all_filterable_associations_filtered_out(self):
         customer = Customer.create({

--- a/tests/integration/test_disputes.py
+++ b/tests/integration/test_disputes.py
@@ -45,9 +45,9 @@ class TestDisputes(unittest.TestCase):
         self.assertEqual(result.errors.for_object("dispute")[0].code, ErrorCodes.Dispute.CanOnlyAcceptOpenDispute)
         self.assertEqual(result.errors.for_object("dispute")[0].message, "Disputes can only be accepted when they are in an Open state")
 
-    @raises_with_regexp(NotFoundError, "dispute with id 'invalid-id' not found")
     def test_accept_raises_error_when_dispute_not_found(self):
-        dispute = Dispute.accept("invalid-id")
+        with self.assertRaisesRegex(NotFoundError, "dispute with id 'invalid-id' not found"):
+            dispute = Dispute.accept("invalid-id")
 
     def test_add_file_evidence_adds_evidence(self):
         dispute = self.create_sample_dispute()
@@ -70,9 +70,9 @@ class TestDisputes(unittest.TestCase):
         self.assertTrue(result.is_success)
         self.assertEqual(result.evidence.category, "GENERAL")
 
-    @raises_with_regexp(NotFoundError, "dispute with id 'unknown_dispute_id' not found")
     def test_add_file_evidence_raises_error_when_dispute_not_found(self):
-        dispute = Dispute.add_file_evidence("unknown_dispute_id", "text evidence")
+        with self.assertRaisesRegex(NotFoundError, "dispute with id 'unknown_dispute_id' not found"):
+            dispute = Dispute.add_file_evidence("unknown_dispute_id", "text evidence")
 
     def test_add_file_evidence_raises_error_when_dispute_not_open(self):
         dispute = self.create_sample_dispute()
@@ -132,9 +132,9 @@ class TestDisputes(unittest.TestCase):
         self.assertEqual(evidence.category, "DEVICE_ID")
         self.assertEqual(evidence.sequence_number, 0)
 
-    @raises_with_regexp(NotFoundError, "Dispute with ID 'unknown_dispute_id' not found")
     def test_add_text_evidence_raises_error_when_dispute_not_found(self):
-        dispute = Dispute.add_text_evidence("unknown_dispute_id", "text evidence")
+        with self.assertRaisesRegex(NotFoundError, "Dispute with ID 'unknown_dispute_id' not found"):
+            dispute = Dispute.add_text_evidence("unknown_dispute_id", "text evidence")
 
     def test_add_text_evidence_raises_error_when_dispute_not_open(self):
         dispute = self.create_sample_dispute()
@@ -230,9 +230,9 @@ class TestDisputes(unittest.TestCase):
         error_codes = [error.code for error in result.errors.for_object("dispute")]
         self.assertIn(ErrorCodes.Dispute.NonDisputedPriorTransactionEvidenceMissingDate, error_codes)
 
-    @raises_with_regexp(NotFoundError, "dispute with id 'invalid-id' not found")
     def test_finalize_raises_error_when_dispute_not_found(self):
-        dispute = Dispute.finalize("invalid-id")
+        with self.assertRaisesRegex(NotFoundError, "dispute with id 'invalid-id' not found"):
+            dispute = Dispute.finalize("invalid-id")
 
     def test_find_returns_dispute_with_given_id(self):
         dispute = Dispute.find("open_dispute")
@@ -245,9 +245,9 @@ class TestDisputes(unittest.TestCase):
         self.assertEqual(None, dispute.transaction.installment_count)
         self.assertNotEqual(None, dispute.graphql_id)
 
-    @raises_with_regexp(NotFoundError, "dispute with id 'invalid-id' not found")
     def test_find_raises_error_when_dispute_not_found(self):
-        dispute = Dispute.find("invalid-id")
+        with self.assertRaisesRegex(NotFoundError, "dispute with id 'invalid-id' not found"):
+            dispute = Dispute.find("invalid-id")
 
     def test_remove_evidence_removes_evidence_from_the_dispute(self):
         dispute = self.create_sample_dispute()
@@ -256,9 +256,9 @@ class TestDisputes(unittest.TestCase):
 
         self.assertTrue(result.is_success)
 
-    @raises_with_regexp(NotFoundError, "evidence with id 'unknown_evidence_id' for dispute with id 'unknown_dispute_id' not found")
     def test_remove_evidence_raises_error_when_dispute_or_evidence_not_found(self):
-        Dispute.remove_evidence("unknown_dispute_id", "unknown_evidence_id")
+        with self.assertRaisesRegex(NotFoundError, "evidence with id 'unknown_evidence_id' for dispute with id 'unknown_dispute_id' not found"):
+            Dispute.remove_evidence("unknown_dispute_id", "unknown_evidence_id")
 
     def test_remove_evidence_errors_when_dispute_not_open(self):
         dispute = self.create_sample_dispute()

--- a/tests/integration/test_document_upload.py
+++ b/tests/integration/test_document_upload.py
@@ -1,5 +1,4 @@
 import os
-from nose.exc import SkipTest
 from tests.test_helper import *
 from braintree.test.nonces import Nonces
 
@@ -98,23 +97,23 @@ class TestDocumentUpload(unittest.TestCase):
 
         self.assertEqual(result.errors.for_object("document_upload")[0].code, ErrorCodes.DocumentUpload.FileIsTooLong)
 
-    @raises_with_regexp(KeyError, "'Invalid keys: invalid_key'")
     def test_create_returns_invalid_keys_errors_with_invalid_signature(self):
-        result = DocumentUpload.create({
-            "kind": braintree.DocumentUpload.Kind.EvidenceDocument,
-            "invalid_key": "do not add"
-        })
+        with self.assertRaisesRegex(KeyError, "'Invalid keys: invalid_key'"):
+            result = DocumentUpload.create({
+                "kind": braintree.DocumentUpload.Kind.EvidenceDocument,
+                "invalid_key": "do not add"
+            })
 
-    @raises_with_regexp(ValueError, "file must be a file handle")
     def test_create_throws_error_when_not_valid_file(self):
-        result = DocumentUpload.create({
-            "kind": braintree.DocumentUpload.Kind.EvidenceDocument,
-            "file": "not_a_file"
-        })
+        with self.assertRaisesRegex(ValueError, "file must be a file handle"):
+            result = DocumentUpload.create({
+                "kind": braintree.DocumentUpload.Kind.EvidenceDocument,
+                "file": "not_a_file"
+            })
 
-    @raises_with_regexp(ValueError, "file must be a file handle")
     def test_create_throws_error_when_none_file(self):
-        result = DocumentUpload.create({
-            "kind": braintree.DocumentUpload.Kind.EvidenceDocument,
-            "file": None
-        })
+        with self.assertRaisesRegex(ValueError, "file must be a file handle"):
+            result = DocumentUpload.create({
+                "kind": braintree.DocumentUpload.Kind.EvidenceDocument,
+                "file": None
+            })

--- a/tests/integration/test_http.py
+++ b/tests/integration/test_http.py
@@ -15,15 +15,15 @@ class TestHttp(unittest.TestCase):
         config = Configuration(environment, "merchant_id", public_key="public_key", private_key="private_key")
         return config.http()
 
-    @raises(AuthenticationError)
     def test_successful_connection_sandbox(self):
-        http = self.get_http(Environment.Sandbox)
-        http.get("/")
+        with self.assertRaises(AuthenticationError):
+            http = self.get_http(Environment.Sandbox)
+            http.get("/")
 
-    @raises(AuthenticationError)
     def test_successful_connection_production(self):
-        http = self.get_http(Environment.Production)
-        http.get("/")
+        with self.assertRaises(AuthenticationError):
+            http = self.get_http(Environment.Production)
+            http.get("/")
 
     def test_wrapping_http_exceptions(self):
         config = Configuration(

--- a/tests/integration/test_merchant_account.py
+++ b/tests/integration/test_merchant_account.py
@@ -398,9 +398,9 @@ class TestMerchantAccount(unittest.TestCase):
         self.assertEqual(merchant_account.status, MerchantAccount.Status.Active)
         self.assertTrue(merchant_account.default)
 
-    @raises(NotFoundError)
     def test_find_404(self):
-        MerchantAccount.find("not_a_real_id")
+        with self.assertRaises(NotFoundError):
+            MerchantAccount.find("not_a_real_id")
 
     def test_merchant_account_create_for_currency(self):
         self.gateway = BraintreeGateway(

--- a/tests/integration/test_plan.py
+++ b/tests/integration/test_plan.py
@@ -120,9 +120,9 @@ class TestPlan(unittest.TestCase):
         self.assertEqual(created_plan.price, found_plan.price)
         self.assertEqual(created_plan.billing_day_of_month, found_plan.billing_day_of_month)
 
-    @raises_with_regexp(NotFoundError, "Plan with id 'bad_token' not found")
     def test_find_with_invalid_token(self):
-        Plan.find("bad_token")
+        with self.assertRaisesRegex(NotFoundError, "Plan with id 'bad_token' not found"):
+            Plan.find("bad_token")
 
     def test_update_returns_successful_result_if_valid(self):
         plan_attributes = {

--- a/tests/integration/test_subscription.py
+++ b/tests/integration/test_subscription.py
@@ -563,9 +563,9 @@ class TestSubscription(unittest.TestCase):
         found_subscription = Subscription.find(subscription.id)
         self.assertEqual(subscription.id, found_subscription.id)
 
-    @raises_with_regexp(NotFoundError, "subscription with id 'bad_token' not found")
     def test_find_with_invalid_token(self):
-        Subscription.find("bad_token")
+        with self.assertRaisesRegex(NotFoundError, "subscription with id 'bad_token' not found"):
+            Subscription.find("bad_token")
 
     def test_update_creates_a_prorated_transaction_when_merchant_is_set_to_prorate(self):
         result = Subscription.update(self.updateable_subscription.id, {
@@ -743,11 +743,11 @@ class TestSubscription(unittest.TestCase):
         self.assertEqual(1, len(id_errors))
         self.assertEqual("81906", id_errors[0].code)
 
-    @raises(NotFoundError)
     def test_update_raises_error_when_subscription_not_found(self):
-        Subscription.update("notfound", {
-            "id": "newid",
-        })
+        with self.assertRaises(NotFoundError):
+            Subscription.update("notfound", {
+                "id": "newid",
+            })
 
     def test_update_allows_overriding_of_inherited_add_ons_and_discounts(self):
         subscription = Subscription.create({
@@ -1034,9 +1034,9 @@ class TestSubscription(unittest.TestCase):
         self.assertTrue(len(status_errors), 1)
         self.assertEqual("81905", status_errors[0].code)
 
-    @raises(NotFoundError)
     def test_cancel_raises_not_found_error_with_bad_subscription(self):
-        Subscription.cancel("notreal")
+        with self.assertRaises(NotFoundError):
+            Subscription.cancel("notreal")
 
     def test_search_with_argument_list_rather_than_literal_list(self):
         trial_subscription = Subscription.create({

--- a/tests/integration/test_testing_gateway.py
+++ b/tests/integration/test_testing_gateway.py
@@ -8,30 +8,30 @@ class TestTestingGateway(unittest.TestCase):
         braintree_gateway = BraintreeGateway(config)
         self.gateway = TestingGateway(braintree_gateway)
 
-    @raises(TestOperationPerformedInProductionError)
     def test_error_is_raised_in_production_for_settle_transaction(self):
-        self.gateway.settle_transaction("")
+        with self.assertRaises(TestOperationPerformedInProductionError):
+            self.gateway.settle_transaction("")
 
-    @raises(TestOperationPerformedInProductionError)
     def test_error_is_raised_in_production_for_make_past_due(self):
-        self.gateway.make_past_due("")
+        with self.assertRaises(TestOperationPerformedInProductionError):
+            self.gateway.make_past_due("")
 
-    @raises(TestOperationPerformedInProductionError)
     def test_error_is_raised_in_production_for_escrow_transaction(self):
-        self.gateway.escrow_transaction("")
+        with self.assertRaises(TestOperationPerformedInProductionError):
+            self.gateway.escrow_transaction("")
 
-    @raises(TestOperationPerformedInProductionError)
     def test_error_is_raised_in_production_for_settlement_confirm_transaction(self):
-        self.gateway.settlement_confirm_transaction("")
+        with self.assertRaises(TestOperationPerformedInProductionError):
+            self.gateway.settlement_confirm_transaction("")
 
-    @raises(TestOperationPerformedInProductionError)
     def test_error_is_raised_in_production_for_settlement_decline_transaction(self):
-        self.gateway.settlement_decline_transaction("")
+        with self.assertRaises(TestOperationPerformedInProductionError):
+            self.gateway.settlement_decline_transaction("")
 
-    @raises(TestOperationPerformedInProductionError)
     def test_error_is_raised_in_production_for_create_3ds_verification(self):
-        self.gateway.create_3ds_verification("", "")
+        with self.assertRaises(TestOperationPerformedInProductionError):
+            self.gateway.create_3ds_verification("", "")
 
-    @raises(TestOperationPerformedInProductionError)
     def test_error_is_raised_in_production(self):
-        self.gateway.settle_transaction("")
+        with self.assertRaises(TestOperationPerformedInProductionError):
+            self.gateway.settle_transaction("")

--- a/tests/integration/test_transaction.py
+++ b/tests/integration/test_transaction.py
@@ -3177,9 +3177,9 @@ class TestTransaction(unittest.TestCase):
         self.assertEqual(transaction.id, found_transaction.id)
         self.assertNotEqual(None, transaction.graphql_id)
 
-    @raises_with_regexp(NotFoundError, "transaction with id 'notreal' not found")
     def test_find_for_bad_transaction_raises_not_found_error(self):
-        Transaction.find("notreal")
+        with self.assertRaisesRegex(NotFoundError, "transaction with id 'notreal' not found"):
+            Transaction.find("notreal")
 
     def test_void_with_successful_result(self):
         transaction = Transaction.sale({
@@ -3368,7 +3368,6 @@ class TestTransaction(unittest.TestCase):
 
         self.assertEqual(Transaction.Status.SubmittedForSettlement, submitted_transaction.status)
 
-    @raises_with_regexp(KeyError, "'Invalid keys: invalid_param'")
     def test_submit_for_settlement_with_invalid_params(self):
         transaction = Transaction.sale({
             "amount": TransactionAmounts.Authorize,
@@ -3387,7 +3386,8 @@ class TestTransaction(unittest.TestCase):
             "invalid_param": "foo",
         }
 
-        Transaction.submit_for_settlement(transaction.id, Decimal("900"), params)
+        with self.assertRaisesRegex(KeyError, "'Invalid keys: invalid_param'"):
+            Transaction.submit_for_settlement(transaction.id, Decimal("900"), params)
 
     def test_submit_for_settlement_with_validation_error(self):
         transaction = Transaction.sale({
@@ -3457,7 +3457,6 @@ class TestTransaction(unittest.TestCase):
         self.assertEqual("3334445555", result.transaction.descriptor.phone)
         self.assertEqual("ebay.com", result.transaction.descriptor.url)
 
-    @raises_with_regexp(KeyError, "'Invalid keys: invalid_key'")
     def test_update_details_with_invalid_params(self):
         transaction = Transaction.sale({
             "amount": "10.00",
@@ -3481,7 +3480,8 @@ class TestTransaction(unittest.TestCase):
             }
         }
 
-        Transaction.update_details(transaction.id, params)
+        with self.assertRaisesRegex(KeyError, "'Invalid keys: invalid_key'"):
+            Transaction.update_details(transaction.id, params)
 
     def test_update_details_with_invalid_order_id(self):
         transaction = Transaction.sale({
@@ -5561,7 +5561,6 @@ class TestTransaction(unittest.TestCase):
         self.assertEqual("3334445555", submitted_transaction.descriptor.phone)
         self.assertEqual("ebay.com", submitted_transaction.descriptor.url)
 
-    @raises_with_regexp(KeyError, "'Invalid keys: invalid_param'")
     def test_submit_for_partial_settlement_with_invalid_params(self):
         transaction = Transaction.sale({
             "amount": TransactionAmounts.Authorize,
@@ -5580,7 +5579,8 @@ class TestTransaction(unittest.TestCase):
             "invalid_param": "foo",
         }
 
-        Transaction.submit_for_partial_settlement(transaction.id, Decimal("900"), params)
+        with self.assertRaisesRegex(KeyError, "'Invalid keys: invalid_param'"):
+            Transaction.submit_for_partial_settlement(transaction.id, Decimal("900"), params)
 
     def test_facilitated_transaction(self):
         granting_gateway, credit_card = TestHelper.create_payment_method_grant_fixtures()

--- a/tests/integration/test_transaction_line_item_gateway.py
+++ b/tests/integration/test_transaction_line_item_gateway.py
@@ -2,7 +2,7 @@ from tests.test_helper import *
 
 class TestTransactionLineItemGateway(unittest.TestCase):
 
-    @raises(NotFoundError)
     def test_transaction_line_item_gateway_find_all_raises_when_transaction_not_found(self):
-        transaction_id = "willnotbefound"
-        TransactionLineItem.find_all(transaction_id)
+        with self.assertRaises(NotFoundError):
+            transaction_id = "willnotbefound"
+            TransactionLineItem.find_all(transaction_id)

--- a/tests/integration/test_transaction_search.py
+++ b/tests/integration/test_transaction_search.py
@@ -420,9 +420,9 @@ class TestTransactionSearch(unittest.TestCase):
 
         self.assertEqual(0, collection.maximum_size)
 
-    @raises_with_regexp(AttributeError, "Invalid argument\(s\) for created_using: noSuchCreatedUsing")
     def test_advanced_search_multiple_value_node_allowed_values_created_using(self):
-        Transaction.search([TransactionSearch.created_using == "noSuchCreatedUsing"])
+        with self.assertRaisesRegex(AttributeError, "Invalid argument\(s\) for created_using: noSuchCreatedUsing"):
+            Transaction.search([TransactionSearch.created_using == "noSuchCreatedUsing"])
 
     def test_advanced_search_multiple_value_node_credit_card_customer_location(self):
         transaction = Transaction.sale({
@@ -456,12 +456,12 @@ class TestTransactionSearch(unittest.TestCase):
 
         self.assertEqual(0, collection.maximum_size)
 
-    @raises_with_regexp(AttributeError,
-            "Invalid argument\(s\) for credit_card_customer_location: noSuchCreditCardCustomerLocation")
     def test_advanced_search_multiple_value_node_allowed_values_credit_card_customer_location(self):
-        Transaction.search([
-            TransactionSearch.credit_card_customer_location == "noSuchCreditCardCustomerLocation"
-        ])
+        with self.assertRaisesRegex(AttributeError,
+            "Invalid argument\(s\) for credit_card_customer_location: noSuchCreditCardCustomerLocation"):
+            Transaction.search([
+                TransactionSearch.credit_card_customer_location == "noSuchCreditCardCustomerLocation"
+            ])
 
     def test_advanced_search_multiple_value_node_merchant_account_id(self):
         transaction = Transaction.sale({
@@ -587,12 +587,12 @@ class TestTransactionSearch(unittest.TestCase):
         self.assertEqual(transaction.id, collection.first.id)
         self.assertEqual(transaction.credit_card_details.card_type, collection.first.credit_card_details.card_type)
 
-    @raises_with_regexp(AttributeError,
-            "Invalid argument\(s\) for credit_card_card_type: noSuchCreditCardCardType")
     def test_advanced_search_multiple_value_node_allowed_values_credit_card_card_type(self):
-        Transaction.search([
-            TransactionSearch.credit_card_card_type == "noSuchCreditCardCardType"
-        ])
+        with self.assertRaisesRegex(AttributeError,
+                "Invalid argument\(s\) for credit_card_card_type: noSuchCreditCardCardType"):
+            Transaction.search([
+                TransactionSearch.credit_card_card_type == "noSuchCreditCardCardType"
+            ])
 
     def test_advanced_search_multiple_value_node_status(self):
         transaction = Transaction.sale({
@@ -649,9 +649,9 @@ class TestTransactionSearch(unittest.TestCase):
 
         self.assertEqual(1, collection.maximum_size)
 
-    @raises_with_regexp(AttributeError, "Invalid argument\(s\) for status: noSuchStatus")
     def test_advanced_search_multiple_value_node_allowed_values_status(self):
-        Transaction.search([TransactionSearch.status == "noSuchStatus"])
+        with self.assertRaisesRegex(AttributeError, "Invalid argument\(s\) for status: noSuchStatus"):
+            Transaction.search([TransactionSearch.status == "noSuchStatus"])
 
     def test_advanced_search_multiple_value_node_source(self):
         transaction = Transaction.sale({
@@ -717,11 +717,11 @@ class TestTransactionSearch(unittest.TestCase):
 
         self.assertEqual(0, collection.maximum_size)
 
-    @raises_with_regexp(AttributeError, "Invalid argument\(s\) for type: noSuchType")
     def test_advanced_search_multiple_value_node_allowed_values_type(self):
-        Transaction.search([
-            TransactionSearch.type == "noSuchType"
-        ])
+        with self.assertRaisesRegex(AttributeError, "Invalid argument\(s\) for type: noSuchType"):
+            Transaction.search([
+                TransactionSearch.type == "noSuchType"
+            ])
 
     def test_advanced_search_multiple_value_node_type_with_refund(self):
         name = "Anabel Atkins%s" % random.randint(1, 100000)
@@ -1616,12 +1616,11 @@ class TestTransactionSearch(unittest.TestCase):
 
         self.assertEqual(0, collection.maximum_size)
 
-
-    @raises(RequestTimeoutError)
     def test_search_handles_a_search_timeout(self):
-        Transaction.search([
-            TransactionSearch.amount.between("-1100", "1600")
-        ])
+        with self.assertRaises(RequestTimeoutError):
+            Transaction.search([
+                TransactionSearch.amount.between("-1100", "1600")
+            ])
 
     def test_search_returns_records_from_valid_daterange(self):
         yesterday = datetime.now() - timedelta(days=1)
@@ -1629,8 +1628,8 @@ class TestTransactionSearch(unittest.TestCase):
 
         collection = Transaction.search([
             TransactionSearch.ach_return_responses_created_at.between(yesterday, tomorrow)
-        ]) 
-        self.assertEqual(2, collection.maximum_size) 
+        ])
+        self.assertEqual(2, collection.maximum_size)
 
     def test_search_returns_records_from_invalid_daterange(self):
         day_after_tomorrow = datetime.now() + timedelta(days=1)
@@ -1638,7 +1637,7 @@ class TestTransactionSearch(unittest.TestCase):
 
         collection = Transaction.search([
             TransactionSearch.ach_return_responses_created_at.between(tomorrow, day_after_tomorrow)
-        ]) 
+        ])
         self.assertEqual(0, collection.maximum_size)
 
     def test_search_returns_records_for_one_reasoncode(self):

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -4,7 +4,6 @@ from datetime import date, datetime, timedelta
 from decimal import Decimal
 from enum import Enum
 from http.client import HTTPConnection
-from nose.tools import make_decorator, raises
 from subprocess import Popen, PIPE
 from urllib.parse import urlencode, quote_plus
 import json
@@ -24,28 +23,6 @@ from braintree.test.credit_card_numbers import CreditCardNumbers
 from braintree.test.nonces import Nonces
 from braintree.testing_gateway import *
 from braintree.util import *
-
-def raises_with_regexp(expected_exception_class, regexp_to_match):
-    def decorate(func):
-        name = func.__name__
-        def generated_function(*args, **kwargs):
-            exception_string = None
-            try:
-                func(*args, **kwargs)
-            except expected_exception_class as e:
-                exception_string = str(e)
-            except:
-                raise
-
-            if exception_string is None:
-                message = "%s() did not raise %s" % (name, expected_exception_class.__name__)
-                raise AssertionError(message)
-            elif re.match(regexp_to_match, exception_string) is None:
-                message = "%s() exception message (%s) did not match (%s)" % \
-                    (name, exception_string, regexp_to_match)
-                raise AssertionError(message)
-        return make_decorator(func)(generated_function)
-    return decorate
 
 def reset_braintree_configuration():
     Configuration.configure(

--- a/tests/unit/test_address.py
+++ b/tests/unit/test_address.py
@@ -1,58 +1,58 @@
 from tests.test_helper import *
 
 class TestAddress(unittest.TestCase):
-    @raises_with_regexp(KeyError, "'Invalid keys: bad_key'")
     def test_create_raise_exception_with_bad_keys(self):
-        Address.create({"customer_id": "12345", "bad_key": "value"})
+        with self.assertRaisesRegex(KeyError, "'Invalid keys: bad_key'"):
+            Address.create({"customer_id": "12345", "bad_key": "value"})
 
-    @raises_with_regexp(KeyError, "'customer_id must be provided'")
     def test_create_raises_error_if_no_customer_id_given(self):
-        Address.create({"country_name": "United States of America"})
+        with self.assertRaisesRegex(KeyError, "'customer_id must be provided'"):
+            Address.create({"country_name": "United States of America"})
 
-    @raises_with_regexp(KeyError, "'customer_id contains invalid characters'")
     def test_create_raises_key_error_if_given_invalid_customer_id(self):
-        Address.create({"customer_id": "!@#$%"})
+        with self.assertRaisesRegex(KeyError, "'customer_id contains invalid characters'"):
+            Address.create({"customer_id": "!@#$%"})
 
-    @raises_with_regexp(KeyError, "'Invalid keys: bad_key'")
     def test_update_raise_exception_with_bad_keys(self):
-        Address.update("customer_id", "address_id", {"bad_key": "value"})
+        with self.assertRaisesRegex(KeyError, "'Invalid keys: bad_key'"):
+            Address.update("customer_id", "address_id", {"bad_key": "value"})
 
-    @raises_with_regexp(KeyError, "'customer_id contains invalid characters'")
     def test_update_raises_key_error_if_given_invalid_customer_id(self):
-        Address.update("!@#$%", "foo")
+        with self.assertRaisesRegex(KeyError, "'customer_id contains invalid characters'"):
+            Address.update("!@#$%", "foo")
 
-    @raises_with_regexp(KeyError, "'address_id contains invalid characters'")
     def test_update_raises_key_error_if_given_invalid_address_id(self):
-        Address.update("foo", "!@#$%")
+        with self.assertRaisesRegex(KeyError, "'address_id contains invalid characters'"):
+            Address.update("foo", "!@#$%")
 
-    @raises_with_regexp(KeyError, "'customer_id contains invalid characters'")
     def test_delete_raises_key_error_if_given_invalid_customer_id(self):
-        Address.delete("!@#$%", "foo")
+        with self.assertRaisesRegex(KeyError, "'customer_id contains invalid characters'"):
+            Address.delete("!@#$%", "foo")
 
-    @raises_with_regexp(KeyError, "'address_id contains invalid characters'")
     def test_delete_raises_key_error_if_given_invalid_address_id(self):
-        Address.delete("foo", "!@#$%")
+        with self.assertRaisesRegex(KeyError, "'address_id contains invalid characters'"):
+            Address.delete("foo", "!@#$%")
 
-    @raises(NotFoundError)
     def test_finding_address_with_empty_customer_id_raises_not_found_exception(self):
-        Address.find(" ", "address_id")
+        with self.assertRaises(NotFoundError):
+            Address.find(" ", "address_id")
 
-    @raises(NotFoundError)
     def test_finding_address_with_none_customer_id_raises_not_found_exception(self):
-        Address.find(None, "address_id")
+        with self.assertRaises(NotFoundError):
+            Address.find(None, "address_id")
 
-    @raises(NotFoundError)
     def test_finding_address_with_empty_address_id_raises_not_found_exception(self):
-        Address.find("customer_id", " ")
+        with self.assertRaises(NotFoundError):
+            Address.find("customer_id", " ")
 
-    @raises(NotFoundError)
     def test_finding_address_with_none_address_id_raises_not_found_exception(self):
-        Address.find("customer_id", None)
+        with self.assertRaises(NotFoundError):
+            Address.find("customer_id", None)
 
-    @raises_with_regexp(KeyError, "'customer_id contains invalid characters'")
     def test_find_raises_key_error_if_given_invalid_customer_id(self):
-        Address.find("!@#$%", "foo")
+        with self.assertRaisesRegex(KeyError, "'customer_id contains invalid characters'"):
+            Address.find("!@#$%", "foo")
 
-    @raises_with_regexp(KeyError, "'address_id contains invalid characters'")
     def test_find_raises_key_error_if_given_invalid_address_id(self):
-        Address.find("foo", "!@#$%")
+        with self.assertRaisesRegex(KeyError, "'address_id contains invalid characters'"):
+            Address.find("foo", "!@#$%")

--- a/tests/unit/test_credit_card.py
+++ b/tests/unit/test_credit_card.py
@@ -2,13 +2,13 @@ from tests.test_helper import *
 import datetime
 
 class TestCreditCard(unittest.TestCase):
-    @raises_with_regexp(KeyError, "'Invalid keys: bad_key'")
     def test_create_raises_exception_with_bad_keys(self):
-        CreditCard.create({"bad_key": "value"})
+        with self.assertRaisesRegex(KeyError, "'Invalid keys: bad_key'"):
+            CreditCard.create({"bad_key": "value"})
 
-    @raises_with_regexp(KeyError, "'Invalid keys: bad_key'")
     def test_update_raises_exception_with_bad_keys(self):
-        CreditCard.update("token", {"bad_key": "value"})
+        with self.assertRaisesRegex(KeyError, "'Invalid keys: bad_key'"):
+            CreditCard.update("token", {"bad_key": "value"})
 
     def test_create_signature(self):
         expected = ["billing_address_id", "cardholder_name", "cvv", "expiration_date", "expiration_month",
@@ -72,21 +72,21 @@ class TestCreditCard(unittest.TestCase):
         ]
         self.assertEqual(expected, CreditCard.update_signature())
 
-    @raises(NotFoundError)
     def test_finding_empty_id_raises_not_found_exception(self):
-        CreditCard.find(" ")
+        with self.assertRaises(NotFoundError):
+            CreditCard.find(" ")
 
-    @raises(NotFoundError)
     def test_finding_none_raises_not_found_exception(self):
-        CreditCard.find(None)
+        with self.assertRaises(NotFoundError):
+            CreditCard.find(None)
 
-    @raises(NotFoundError)
     def test_from_nonce_empty_id_raises_not_found_exception(self):
-        CreditCard.from_nonce(" ")
+        with self.assertRaises(NotFoundError):
+            CreditCard.from_nonce(" ")
 
-    @raises(NotFoundError)
     def test_from_nonce_none_raises_not_found_exception(self):
-        CreditCard.from_nonce(None)
+        with self.assertRaises(NotFoundError):
+            CreditCard.from_nonce(None)
 
     def test_multiple_verifications_sort(self):
         verification1 = {"created_at": datetime.datetime(2014, 11, 18, 23, 20, 20), "id": 123, "amount": "0.00"}

--- a/tests/unit/test_credit_card_verification.py
+++ b/tests/unit/test_credit_card_verification.py
@@ -2,9 +2,9 @@ from tests.test_helper import *
 
 class TestCreditCardVerification(unittest.TestCase):
 
-    @raises_with_regexp(KeyError, "'Invalid keys: bad_key'")
     def test_create_raises_exception_with_bad_keys(self):
-        CreditCardVerification.create({"bad_key": "value", "credit_card": {"number": "value"}})
+        with self.assertRaisesRegex(KeyError, "'Invalid keys: bad_key'"):
+            CreditCardVerification.create({"bad_key": "value", "credit_card": {"number": "value"}})
 
     def test_constructor_with_amount(self):
         attributes = {
@@ -49,10 +49,10 @@ class TestCreditCardVerification(unittest.TestCase):
         self.assertEqual(verification.network_response_code, None)
         self.assertEqual(verification.network_response_text, None)
 
-    @raises(NotFoundError)
     def test_finding_empty_id_raises_not_found_exception(self):
-        CreditCardVerification.find(" ")
+        with self.assertRaises(NotFoundError):
+            CreditCardVerification.find(" ")
 
-    @raises(NotFoundError)
     def test_finding_none_raises_not_found_exception(self):
-        CreditCardVerification.find(None)
+        with self.assertRaises(NotFoundError):
+            CreditCardVerification.find(None)

--- a/tests/unit/test_customer.py
+++ b/tests/unit/test_customer.py
@@ -1,29 +1,29 @@
 from tests.test_helper import *
 
 class TestCustomer(unittest.TestCase):
-    @raises_with_regexp(KeyError, "'Invalid keys: bad_key'")
     def test_create_raise_exception_with_bad_keys(self):
-        Customer.create({"bad_key": "value"})
+        with self.assertRaisesRegex(KeyError, "'Invalid keys: bad_key'"):
+            Customer.create({"bad_key": "value"})
 
-    @raises_with_regexp(KeyError, "'Invalid keys: credit_card\[bad_key\]'")
     def test_create_raise_exception_with_bad_nested_keys(self):
-        Customer.create({"credit_card": {"bad_key": "value"}})
+        with self.assertRaisesRegex(KeyError, "'Invalid keys: credit_card\[bad_key\]'"):
+            Customer.create({"credit_card": {"bad_key": "value"}})
 
-    @raises_with_regexp(KeyError, "'Invalid keys: bad_key'")
     def test_update_raise_exception_with_bad_keys(self):
-        Customer.update("id", {"bad_key": "value"})
+        with self.assertRaisesRegex(KeyError, "'Invalid keys: bad_key'"):
+            Customer.update("id", {"bad_key": "value"})
 
-    @raises_with_regexp(KeyError, "'Invalid keys: credit_card\[bad_key\]'")
     def test_update_raise_exception_with_bad_nested_keys(self):
-        Customer.update("id", {"credit_card": {"bad_key": "value"}})
+        with self.assertRaisesRegex(KeyError, "'Invalid keys: credit_card\[bad_key\]'"):
+            Customer.update("id", {"credit_card": {"bad_key": "value"}})
 
-    @raises(NotFoundError)
     def test_finding_empty_id_raises_not_found_exception(self):
-        Customer.find(" ")
+        with self.assertRaises(NotFoundError):
+            Customer.find(" ")
 
-    @raises(NotFoundError)
     def test_finding_none_raises_not_found_exception(self):
-        Customer.find(None)
+        with self.assertRaises(NotFoundError):
+            Customer.find(None)
 
     def test_initialize_sets_paypal_accounts(self):
         customer = Customer("gateway", {

--- a/tests/unit/test_dispute.py
+++ b/tests/unit/test_dispute.py
@@ -177,90 +177,90 @@ class TestDispute(unittest.TestCase):
         self.assertEqual(dispute.transaction.purchase_order_number, "po")
         self.assertEqual(dispute.transaction.payment_instrument_subtype, "Visa")
 
-    @raises_with_regexp(NotFoundError, "dispute with id None not found")
     def test_accept_none_raises_not_found_exception(self):
-        Dispute.accept(None)
+        with self.assertRaisesRegex(NotFoundError, "dispute with id None not found"):
+            Dispute.accept(None)
 
-    @raises_with_regexp(NotFoundError, "dispute with id ' ' not found")
     def test_accept_empty_id_raises_not_found_exception(self):
-        Dispute.accept(" ")
+        with self.assertRaisesRegex(NotFoundError, "dispute with id ' ' not found"):
+            Dispute.accept(" ")
 
-    @raises_with_regexp(NotFoundError, "dispute_id cannot be blank")
     def test_add_text_evidence_empty_id_raises_not_found_exception(self):
-        Dispute.add_text_evidence(" ", "evidence")
+        with self.assertRaisesRegex(NotFoundError, "dispute_id cannot be blank"):
+            Dispute.add_text_evidence(" ", "evidence")
 
-    @raises_with_regexp(NotFoundError, "dispute_id cannot be blank")
     def test_add_text_evidence_none_id_raises_not_found_exception(self):
-        Dispute.add_text_evidence(None, "evidence")
+        with self.assertRaisesRegex(NotFoundError, "dispute_id cannot be blank"):
+            Dispute.add_text_evidence(None, "evidence")
 
-    @raises_with_regexp(ValueError, "content cannot be blank")
     def test_add_text_evidence_empty_evidence_raises_value_exception(self):
-        Dispute.add_text_evidence("dispute_id", " ")
+        with self.assertRaisesRegex(ValueError, "content cannot be blank"):
+            Dispute.add_text_evidence("dispute_id", " ")
 
-    @raises_with_regexp(ValueError, "sequence_number must be an integer")
     def test_add_text_evidence_sequence_number_not_number_evidence_raises_value_exception(self):
-        Dispute.add_text_evidence("dispute_id", { "content": "content", "sequence_number": "a" })
+        with self.assertRaisesRegex(ValueError, "sequence_number must be an integer"):
+            Dispute.add_text_evidence("dispute_id", { "content": "content", "sequence_number": "a" })
 
-    @raises_with_regexp(ValueError, "sequence_number must be an integer")
     def test_add_text_evidence_sequence_number_number_and_letter_evidence_raises_value_exception(self):
-        Dispute.add_text_evidence("dispute_id", { "content": "content", "sequence_number": "1abc" })
+        with self.assertRaisesRegex(ValueError, "sequence_number must be an integer"):
+            Dispute.add_text_evidence("dispute_id", { "content": "content", "sequence_number": "1abc" })
 
-    @raises_with_regexp(ValueError, "category must be a string")
     def test_add_text_evidence_category_is_number_evidence_raises_value_exception(self):
-        Dispute.add_text_evidence("dispute_id", { "content": "content", "category": 5 })
+        with self.assertRaisesRegex(ValueError, "category must be a string"):
+            Dispute.add_text_evidence("dispute_id", { "content": "content", "category": 5 })
 
-    @raises_with_regexp(NotFoundError, "dispute with id ' ' not found")
     def test_add_file_evidence_empty_id_raises_not_found_exception(self):
-        Dispute.add_file_evidence(" ", 1)
+        with self.assertRaisesRegex(NotFoundError, "dispute with id ' ' not found"):
+            Dispute.add_file_evidence(" ", 1)
 
-    @raises_with_regexp(NotFoundError, "dispute with id None not found")
     def test_add_file_evidence_none_id_raises_not_found_exception(self):
-        Dispute.add_file_evidence(None, 1)
+        with self.assertRaisesRegex(NotFoundError, "dispute with id None not found"):
+            Dispute.add_file_evidence(None, 1)
 
-    @raises_with_regexp(ValueError, "document_id cannot be blank")
     def test_add_file_evidence_empty_evidence_raises_value_exception(self):
-        Dispute.add_file_evidence("dispute_id", " ")
+        with self.assertRaisesRegex(ValueError, "document_id cannot be blank"):
+            Dispute.add_file_evidence("dispute_id", " ")
 
-    @raises_with_regexp(ValueError, "document_id cannot be blank")
     def test_add_file_evidence_none_evidence_raises_value_exception(self):
-        Dispute.add_file_evidence("dispute_id", None)
+        with self.assertRaisesRegex(ValueError, "document_id cannot be blank"):
+            Dispute.add_file_evidence("dispute_id", None)
 
-    @raises_with_regexp(ValueError, "category must be a string")
     def test_add_file_evidence_categorized_document_id_must_be_a_string(self):
-        Dispute.add_file_evidence("dispute_id", { "document_id": "213", "category": 5 })
+        with self.assertRaisesRegex(ValueError, "category must be a string"):
+            Dispute.add_file_evidence("dispute_id", { "document_id": "213", "category": 5 })
 
-    @raises_with_regexp(ValueError, "document_id cannot be blank")
     def test_add_file_evidence_empty_categorized_evidence_raises_value_exception(self):
-        Dispute.add_file_evidence("dispute_id", { "category": "DEVICE_ID" })
+        with self.assertRaisesRegex(ValueError, "document_id cannot be blank"):
+            Dispute.add_file_evidence("dispute_id", { "category": "DEVICE_ID" })
 
-    @raises_with_regexp(NotFoundError, "dispute with id None not found")
     def test_finalize_none_raises_not_found_exception(self):
-        Dispute.finalize(None)
+        with self.assertRaisesRegex(NotFoundError, "dispute with id None not found"):
+            Dispute.finalize(None)
 
-    @raises_with_regexp(NotFoundError, "dispute with id ' ' not found")
     def test_finalize_empty_id_raises_not_found_exception(self):
-        Dispute.finalize(" ")
+        with self.assertRaisesRegex(NotFoundError, "dispute with id ' ' not found"):
+            Dispute.finalize(" ")
 
-    @raises_with_regexp(NotFoundError, "dispute with id None not found")
     def test_finding_none_raises_not_found_exception(self):
-        Dispute.find(None)
+        with self.assertRaisesRegex(NotFoundError, "dispute with id None not found"):
+            Dispute.find(None)
 
-    @raises_with_regexp(NotFoundError, "dispute with id ' ' not found")
     def test_finding_empty_id_raises_not_found_exception(self):
-        Dispute.find(" ")
+        with self.assertRaisesRegex(NotFoundError, "dispute with id ' ' not found"):
+            Dispute.find(" ")
 
-    @raises_with_regexp(NotFoundError, "evidence with id 'evidence' for dispute with id ' ' not found")
     def test_remove_evidence_empty_dispute_id_raises_not_found_exception(self):
-        Dispute.remove_evidence(" ", "evidence")
+        with self.assertRaisesRegex(NotFoundError, "evidence with id 'evidence' for dispute with id ' ' not found"):
+            Dispute.remove_evidence(" ", "evidence")
 
-    @raises_with_regexp(NotFoundError, "evidence with id 'evidence' for dispute with id None not found")
     def test_remove_evidence_none_dispute_id_raises_not_found_exception(self):
-        Dispute.remove_evidence(None, "evidence")
+        with self.assertRaisesRegex(NotFoundError, "evidence with id 'evidence' for dispute with id None not found"):
+            Dispute.remove_evidence(None, "evidence")
 
-    @raises_with_regexp(NotFoundError, "evidence with id None for dispute with id 'dispute_id' not found")
     def test_remove_evidence_evidence_none_id_raises_not_found_exception(self):
-        Dispute.remove_evidence("dispute_id", None)
+        with self.assertRaisesRegex(NotFoundError, "evidence with id None for dispute with id 'dispute_id' not found"):
+            Dispute.remove_evidence("dispute_id", None)
 
-    @raises_with_regexp(NotFoundError, "evidence with id ' ' for dispute with id 'dispute_id' not found")
     def test_remove_evidence_empty_evidence_id_raises_value_exception(self):
-        Dispute.remove_evidence("dispute_id", " ")
+        with self.assertRaisesRegex(NotFoundError, "evidence with id ' ' for dispute with id 'dispute_id' not found"):
+            Dispute.remove_evidence("dispute_id", " ")

--- a/tests/unit/test_document_upload.py
+++ b/tests/unit/test_document_upload.py
@@ -1,6 +1,6 @@
 from tests.test_helper import *
 
 class TestDocumentUpload(unittest.TestCase):
-    @raises_with_regexp(KeyError, "'Invalid keys: bad_key'")
     def test_create_raises_exception_with_bad_keys(self):
-        DocumentUpload.create({"bad_key": "value"})
+        with self.assertRaisesRegex(KeyError, "'Invalid keys: bad_key'"):
+            DocumentUpload.create({"bad_key": "value"})

--- a/tests/unit/test_graphql_client.py
+++ b/tests/unit/test_graphql_client.py
@@ -1,7 +1,6 @@
 from tests.test_helper import *
 
 class TestGraphQLClient(unittest.TestCase):
-    @raises(ServiceUnavailableError)
     def test_raise_exception_from_status_service_unavailable(self):
         response = {
             "errors": [
@@ -13,9 +12,9 @@ class TestGraphQLClient(unittest.TestCase):
                 }
             ]
         }
-        GraphQLClient.raise_exception_for_graphql_error(response)
+        with self.assertRaises(ServiceUnavailableError):
+            GraphQLClient.raise_exception_for_graphql_error(response)
 
-    @raises(UpgradeRequiredError)
     def test_raise_exception_from_status_for_upgrade_required(self):
         response = {
             "errors": [
@@ -27,9 +26,9 @@ class TestGraphQLClient(unittest.TestCase):
                 }
             ]
         }
-        GraphQLClient.raise_exception_for_graphql_error(response)
+        with self.assertRaises(UpgradeRequiredError):
+            GraphQLClient.raise_exception_for_graphql_error(response)
 
-    @raises(TooManyRequestsError)
     def test_raise_exception_from_too_many_requests(self):
         response = {
             "errors": [
@@ -41,7 +40,8 @@ class TestGraphQLClient(unittest.TestCase):
                 }
             ]
         }
-        GraphQLClient.raise_exception_for_graphql_error(response)
+        with self.assertRaises(TooManyRequestsError):
+            GraphQLClient.raise_exception_for_graphql_error(response)
 
     def test_does_not_raise_exception_from_validation_error(self):
         response = {
@@ -56,7 +56,6 @@ class TestGraphQLClient(unittest.TestCase):
         }
         GraphQLClient.raise_exception_for_graphql_error(response)
 
-    @raises(ServerError)
     def test_raise_exception_from_validation_error_and_legitimate_error(self):
         response = {
             "errors": [
@@ -74,4 +73,5 @@ class TestGraphQLClient(unittest.TestCase):
                 }
             ]
         }
-        GraphQLClient.raise_exception_for_graphql_error(response)
+        with self.assertRaises(ServerError):
+            GraphQLClient.raise_exception_for_graphql_error(response)

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -5,25 +5,25 @@ from braintree.exceptions.http.timeout_error import *
 from braintree.attribute_getter import AttributeGetter
 
 class TestHttp(unittest.TestCase):
-    @raises(RequestTimeoutError)
     def test_raise_exception_from_request_timeout(self):
-        Http.raise_exception_from_status(408)
+        with self.assertRaises(RequestTimeoutError):
+            Http.raise_exception_from_status(408)
 
-    @raises(UpgradeRequiredError)
     def test_raise_exception_from_status_for_upgrade_required(self):
-        Http.raise_exception_from_status(426)
+        with self.assertRaises(UpgradeRequiredError):
+            Http.raise_exception_from_status(426)
 
-    @raises(TooManyRequestsError)
     def test_raise_exception_from_too_many_requests(self):
-        Http.raise_exception_from_status(429)
+        with self.assertRaises(TooManyRequestsError):
+            Http.raise_exception_from_status(429)
 
-    @raises(ServiceUnavailableError)
     def test_raise_exception_from_service_unavailable(self):
-        Http.raise_exception_from_status(503)
+        with self.assertRaises(ServiceUnavailableError):
+            Http.raise_exception_from_status(503)
 
-    @raises(GatewayTimeoutError)
     def test_raise_exception_from_gateway_timeout(self):
-        Http.raise_exception_from_status(504)
+        with self.assertRaises(GatewayTimeoutError):
+            Http.raise_exception_from_status(504)
 
     def test_header_includes_gzip_accept_encoding(self):
         config = AttributeGetter({
@@ -122,18 +122,18 @@ class TestHttp(unittest.TestCase):
 
         return Http(config, "fake_environment")
 
-    @raises(ReadTimeoutError)
     def test_raise_read_timeout_error(self):
         def test_http_do_strategy(http_verb, path, headers, request_body):
             return (200, "")
 
-        http = self.setup_http_strategy(test_http_do_strategy)
-        http.handle_exception(requests.exceptions.ReadTimeout())
+        with self.assertRaises(ReadTimeoutError):
+            http = self.setup_http_strategy(test_http_do_strategy)
+            http.handle_exception(requests.exceptions.ReadTimeout())
 
-    @raises(ConnectTimeoutError)
     def test_raise_connect_timeout_error(self):
         def test_http_do_strategy(http_verb, path, headers, request_body):
             return (200, "")
 
-        http = self.setup_http_strategy(test_http_do_strategy)
-        http.handle_exception(requests.exceptions.ConnectTimeout())
+        with self.assertRaises(ConnectTimeoutError):
+            http = self.setup_http_strategy(test_http_do_strategy)
+            http.handle_exception(requests.exceptions.ConnectTimeout())

--- a/tests/unit/test_payment_method_nonce.py
+++ b/tests/unit/test_payment_method_nonce.py
@@ -1,10 +1,10 @@
 from tests.test_helper import *
 
 class TestPaymentMethodNonce(unittest.TestCase):
-    @raises(NotFoundError)
     def test_finding_empty_id_raises_not_found_exception(self):
-        PaymentMethodNonce.find(" ")
+        with self.assertRaises(NotFoundError):
+            PaymentMethodNonce.find(" ")
 
-    @raises(NotFoundError)
     def test_finding_None_id_raises_not_found_exception(self):
-        PaymentMethodNonce.find(None)
+        with self.assertRaises(NotFoundError):
+            PaymentMethodNonce.find(None)

--- a/tests/unit/test_resource.py
+++ b/tests/unit/test_resource.py
@@ -16,7 +16,6 @@ class TestResource(unittest.TestCase):
         }
         Resource.verify_keys(params, signature)
 
-    @raises(KeyError)
     def test_verify_keys_escapes_brackets_in_signature(self):
         signature = [
             {"customer": [{"custom_fields": ["__any_key__"]}]}
@@ -24,7 +23,8 @@ class TestResource(unittest.TestCase):
         params = {
             "customer_id": "value",
         }
-        Resource.verify_keys(params, signature)
+        with self.assertRaises(KeyError):
+            Resource.verify_keys(params, signature)
 
     def test_verify_keys_works_with_array_param(self):
         signature = [
@@ -37,7 +37,6 @@ class TestResource(unittest.TestCase):
         }
         Resource.verify_keys(params, signature)
 
-    @raises(KeyError)
     def test_verify_keys_raises_on_bad_array_param(self):
         signature = [
             {"customer": ["one", "two"]}
@@ -47,7 +46,8 @@ class TestResource(unittest.TestCase):
                 "invalid": "foo"
             }
         }
-        Resource.verify_keys(params, signature)
+        with self.assertRaises(KeyError):
+            Resource.verify_keys(params, signature)
 
     def test_verify_keys_works_with_arrays(self):
         signature = [
@@ -65,7 +65,6 @@ class TestResource(unittest.TestCase):
         }
         Resource.verify_keys(params, signature)
 
-    @raises(KeyError)
     def test_verify_keys_raises_with_invalid_param_in_arrays(self):
         signature = [
             {"add_ons": [{"update": ["existing_id", "quantity"]}]}
@@ -80,7 +79,8 @@ class TestResource(unittest.TestCase):
                 ]
             }
         }
-        Resource.verify_keys(params, signature)
+        with self.assertRaises(KeyError):
+            Resource.verify_keys(params, signature)
 
     def test_verify_keys_allows_text(self):
         text_string = u"text_string"

--- a/tests/unit/test_resource_collection.py
+++ b/tests/unit/test_resource_collection.py
@@ -45,7 +45,7 @@ class TestResourceCollection(unittest.TestCase):
         collection = ResourceCollection("some_query", empty_collection_data, TestResourceCollection.TestResource.fetch)
         self.assertEqual(collection.ids, [])
 
-    @raises_with_regexp(UnexpectedError, "Unprocessable entity due to an invalid request")
     def test_no_search_results(self):
         bad_collection_data = {}
-        ResourceCollection("some_query", bad_collection_data, TestResourceCollection.TestResource.fetch)
+        with self.assertRaisesRegex(UnexpectedError, "Unprocessable entity due to an invalid request"):
+            ResourceCollection("some_query", bad_collection_data, TestResourceCollection.TestResource.fetch)

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -37,10 +37,10 @@ class TestSearch(unittest.TestCase):
         node = Search.MultipleValueNodeBuilder("name", ["okay"])
         self.assertEqual(["okay"], (node == "okay").to_param())
 
-    @raises(AttributeError)
     def test_multiple_value_node_with_value_not_in_whitelist(self):
-        node = Search.MultipleValueNodeBuilder("name", ["okay", "also okay"])
-        node == "not okay"
+        with self.assertRaises(AttributeError):
+            node = Search.MultipleValueNodeBuilder("name", ["okay", "also okay"])
+            node == "not okay"
 
     def test_multiple_value_or_text_node_is(self):
         node = Search.MultipleValueOrTextNodeBuilder("name")
@@ -74,10 +74,10 @@ class TestSearch(unittest.TestCase):
         node = Search.MultipleValueOrTextNodeBuilder("name", ["okay"])
         self.assertEqual(["okay"], node.in_list("okay").to_param())
 
-    @raises(AttributeError)
     def test_multiple_value_or_text_node_with_value_not_in_whitelist(self):
-        node = Search.MultipleValueOrTextNodeBuilder("name", ["okay"])
-        node.in_list("not okay").to_param()
+        with self.assertRaises(AttributeError):
+            node = Search.MultipleValueOrTextNodeBuilder("name", ["okay"])
+            node.in_list("not okay").to_param()
 
     def test_range_node_min_ge(self):
         node = Search.RangeNodeBuilder("name")

--- a/tests/unit/test_subscription.py
+++ b/tests/unit/test_subscription.py
@@ -1,18 +1,18 @@
 from tests.test_helper import *
 
 class TestSubscription(unittest.TestCase):
-    @raises_with_regexp(KeyError, "'Invalid keys: bad_key'")
     def test_create_raises_exception_with_bad_keys(self):
-        Subscription.create({"bad_key": "value"})
+        with self.assertRaisesRegex(KeyError, "'Invalid keys: bad_key'"):
+            Subscription.create({"bad_key": "value"})
 
-    @raises_with_regexp(KeyError, "'Invalid keys: bad_key'")
     def test_update_raises_exception_with_bad_keys(self):
-        Subscription.update("id", {"bad_key": "value"})
+        with self.assertRaisesRegex(KeyError, "'Invalid keys: bad_key'"):
+            Subscription.update("id", {"bad_key": "value"})
 
-    @raises(NotFoundError)
     def test_finding_empty_id_raises_not_found_exception(self):
-        Subscription.find(" ")
+        with self.assertRaises(NotFoundError):
+            Subscription.find(" ")
 
-    @raises(NotFoundError)
     def test_finding_None_id_raises_not_found_exception(self):
-        Subscription.find(None)
+        with self.assertRaises(NotFoundError):
+            Subscription.find(None)

--- a/tests/unit/test_subscription_search.py
+++ b/tests/unit/test_subscription_search.py
@@ -36,14 +36,14 @@ class TestSubscriptionSearch(unittest.TestCase):
             Subscription.Status.PastDue
         )
 
-    @raises(AttributeError)
     def test_status_not_in_whitelist(self):
-        SubscriptionSearch.status.in_list(
-            Subscription.Status.Active,
-            Subscription.Status.Canceled,
-            Subscription.Status.Expired,
-            "not a status"
-        )
+        with self.assertRaises(AttributeError):
+            SubscriptionSearch.status.in_list(
+                Subscription.Status.Active,
+                Subscription.Status.Canceled,
+                Subscription.Status.Expired,
+                "not a status"
+            )
 
     def test_ids_is_a_multiple_value_node(self):
         self.assertEqual(Search.MultipleValueNodeBuilder, type(SubscriptionSearch.ids))

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -6,25 +6,25 @@ from braintree.authorization_adjustment import AuthorizationAdjustment
 from unittest.mock import MagicMock
 
 class TestTransaction(unittest.TestCase):
-    @raises_with_regexp(KeyError, "'Invalid keys: bad_key'")
     def test_clone_transaction_raises_exception_with_bad_keys(self):
-        Transaction.clone_transaction("an id", {"bad_key": "value"})
+        with self.assertRaisesRegex(KeyError, "'Invalid keys: bad_key'"):
+            Transaction.clone_transaction("an id", {"bad_key": "value"})
 
-    @raises_with_regexp(KeyError, "'Invalid keys: bad_key'")
     def test_sale_raises_exception_with_bad_keys(self):
-        Transaction.sale({"bad_key": "value"})
+        with self.assertRaisesRegex(KeyError, "'Invalid keys: bad_key'"):
+            Transaction.sale({"bad_key": "value"})
 
-    @raises_with_regexp(KeyError, "'Invalid keys: credit_card\[bad_key\]'")
     def test_sale_raises_exception_with_nested_bad_keys(self):
-        Transaction.sale({"credit_card": {"bad_key": "value"}})
+        with self.assertRaisesRegex(KeyError, "'Invalid keys: credit_card\[bad_key\]'"):
+            Transaction.sale({"credit_card": {"bad_key": "value"}})
 
-    @raises(NotFoundError)
     def test_finding_empty_id_raises_not_found_exception(self):
-        Transaction.find(" ")
+        with self.assertRaises(NotFoundError):
+            Transaction.find(" ")
 
-    @raises(NotFoundError)
     def test_finding_none_raises_not_found_exception(self):
-        Transaction.find(None)
+        with self.assertRaises(NotFoundError):
+            Transaction.find(None)
 
     def test_constructor_includes_disbursement_information(self):
         attributes = {

--- a/tests/unit/test_us_bank_account_verification.py
+++ b/tests/unit/test_us_bank_account_verification.py
@@ -4,13 +4,13 @@ from tests.test_helper import *
 from braintree.us_bank_account_verification import UsBankAccountVerification
 
 class TestUsBankAccountVerification(unittest.TestCase):
-    @raises(NotFoundError)
     def test_finding_empty_id_raises_not_found_exception(self):
-        UsBankAccountVerification.find(" ")
+        with self.assertRaises(NotFoundError):
+            UsBankAccountVerification.find(" ")
 
-    @raises(NotFoundError)
     def test_finding_none_raises_not_found_exception(self):
-        UsBankAccountVerification.find(None)
+        with self.assertRaises(NotFoundError):
+            UsBankAccountVerification.find(None)
 
     def test_attributes(self):
         attributes = {

--- a/tests/unit/test_webhooks.py
+++ b/tests/unit/test_webhooks.py
@@ -44,14 +44,13 @@ class TestWebhooks(unittest.TestCase):
 
         self.assertEqual('my_source_merchant_id', notification.source_merchant_id)
 
-    @raises(InvalidSignatureError)
     def test_completely_invalid_signature(self):
         sample_notification = WebhookTesting.sample_notification(
             WebhookNotification.Kind.SubscriptionWentPastDue,
             "my_id"
         )
-
-        WebhookNotification.parse("bad_stuff", sample_notification['bt_payload'])
+        with self.assertRaises(InvalidSignatureError):
+            WebhookNotification.parse("bad_stuff", sample_notification['bt_payload'])
 
     def test_parse_raises_when_public_key_is_wrong(self):
         sample_notification = WebhookTesting.sample_notification(


### PR DESCRIPTION
# Summary

`nose` is considered deprecated, and has various issues. After some reviewing of nose usage in this library, I noticed that it is very easy to use builtin unittest functionality for it (to use [assertRaises](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertRaises) and [assertRaisesRegex](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertRaisesRegex) instead)

Also, `mock` is unnecessary, as you already use `unittest.mock` everywhere.

I have updated the docs and scripts to use `python3 -m unittest discover` instead of `nosetests`.

# Checklist

- [x] Added changelog entry
- [x] Ran unit tests (`nosetests tests/unit`)
- [x] I understand that unless this is a Draft PR or has a DO NOT MERGE label, this PR is considered to be in a deploy ready state and can be deployed if merged to main

<!-- **For Braintree Developers only, don't forget:**
- [ ] Does this change require work to be done to the GraphQL API? If you have questions check with the GraphQL team.
- [ ] Add & Run integration tests -->
