### PR TITLE
Remove deprecation warnings when importing module

### DIFF
--- a/braintree/dispute.py
+++ b/braintree/dispute.py
@@ -77,7 +77,11 @@ class Dispute(AttributeGetter):
         * braintree.Dispute.ChargebackProtectionLevel.STANDARD
         * braintree.Dispute.ChargebackProtectionLevel.NOT_PROTECTED
         """
-        warnings.warn("Use ProtectionLevel enum instead", DeprecationWarning)
+
+        def __getattribute__(self, name):
+            warnings.warn("Use ProtectionLevel enum instead", DeprecationWarning)
+            return super().__getattribute__(name)
+
         Effortless     = "effortless"
         Standard       = "standard"
         NotProtected   = "not_protected"

--- a/braintree/dispute_search.py
+++ b/braintree/dispute_search.py
@@ -4,9 +4,6 @@ class DisputeSearch:
     amount_disputed             =   Search.RangeNodeBuilder("amount_disputed")
     amount_won                  =   Search.RangeNodeBuilder("amount_won")
     case_number                 =   Search.TextNodeBuilder("case_number")
-    # NEXT_MAJOR_VERSION Remove this attribute
-    # DEPRECATED The chargeback_protection_level attribute is deprecated in favor of protection_level
-    chargeback_protection_level =   Search.MultipleValueNodeBuilder("chargeback_protection_level")
     protection_level            =   Search.MultipleValueNodeBuilder("protection_level")
     customer_id                 =   Search.TextNodeBuilder("customer_id")
     disbursement_date           =   Search.RangeNodeBuilder("disbursement_date")
@@ -23,3 +20,10 @@ class DisputeSearch:
     status                      =   Search.MultipleValueNodeBuilder("status")
     transaction_id              =   Search.TextNodeBuilder("transaction_id")
     transaction_source          =   Search.MultipleValueNodeBuilder("transaction_source")
+
+    # NEXT_MAJOR_VERSION Remove this attribute
+    # DEPRECATED The chargeback_protection_level attribute is deprecated in favor of protection_level
+    def __getattr__(self, item):
+        if item == "chargeback_protection_level":
+            return Search.MultipleValueNodeBuilder("chargeback_protection_level")
+        raise AttributeError()


### PR DESCRIPTION
# Summary

Hide deprecation warnings behind __getattr__ and __getattribute__. Not the ideal solution but fixes the problem. I am open to better solutions.
Fixes #148

# Checklist

- [ ] Added changelog entry
- [x] Ran unit tests (`python3 -m unittest discover tests/unit`)
- [x] I understand that unless this is a Draft PR or has a DO NOT MERGE label, this PR is considered to be in a deploy ready state and can be deployed if merged to main

<!-- **For Braintree Developers only, don't forget:**
- [ ] Does this change require work to be done to the GraphQL API? If you have questions check with the GraphQL team.
- [ ] Add & Run integration tests -->
