### PR TITLE
Fix test suite compatibility with Python 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.24.0
+* Fix unittest compatibility with Python 3.12
+
 ## 4.23.0
 * Deprecate `evidenceSubmittable` in Dispute 
 * Add missing `escape` calls in `generator` for:

--- a/tests/unit/test_client_token.py
+++ b/tests/unit/test_client_token.py
@@ -3,7 +3,7 @@ from tests.test_helper import *
 class TestClientToken(unittest.TestCase):
     def test_credit_card_options_require_customer_id(self):
         for option in ["verify_card", "make_default", "fail_on_duplicate_payment_method"]:
-            with self.assertRaisesRegexp(InvalidSignatureError, option):
+            with self.assertRaisesRegex(InvalidSignatureError, option):
                 ClientToken.generate({
                     "options": {option: True}
                 })

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -1,13 +1,13 @@
 from tests.test_helper import *
 import braintree
 import os
-import imp
+import importlib
 
 class TestConfiguration(unittest.TestCase):
     def test_works_with_unconfigured_configuration(self):
         try:
             # reset class level attributes on Configuration set in test helper
-            imp.reload(braintree.configuration)
+            importlib.reload(braintree.configuration)
             config = Configuration(
                 environment=braintree.Environment.Sandbox,
                 merchant_id='my_merchant_id',
@@ -21,7 +21,7 @@ class TestConfiguration(unittest.TestCase):
         finally:
             # repopulate class level attributes on Configuration
             import tests.test_helper
-            imp.reload(tests.test_helper)
+            importlib.reload(tests.test_helper)
 
     def test_base_merchant_path_for_development(self):
         self.assertEqual("/merchants/integration_merchant_id", Configuration.instantiate().base_merchant_path())


### PR DESCRIPTION
# Summary

Replace the deprecated `unittest.TestCase.assertRaisesRegexp()` method with `assertRaisesRegex()`.  The former is no longer present in Python 3.12, while the latter is available since Python 3.2.

Replace the deprecated `imp.reload()` function with `importlib.reload()`.  The former module is no longer present in Python 3.12, while `importlib.reload()` is available since Python 3.4.

With these changes, unit tests pass with Python 3.12.0.

Fixes #153

# Checklist

- [x] Added changelog entry
- [x] Ran unit tests (`python3 -m unittest discover tests/unit`)
- [x] I understand that unless this is a Draft PR or has a DO NOT MERGE label, this PR is considered to be in a deploy ready state and can be deployed if merged to main